### PR TITLE
[email] Fixed truncated email subject #24

### DIFF
--- a/openwisp_notifications/models.py
+++ b/openwisp_notifications/models.py
@@ -75,7 +75,7 @@ def send_email_notification(sender, instance, created, **kwargs):
     ):
         return
     # send email
-    subject = instance.data.get('email_subject', instance.description[0:24])
+    subject = instance.data.get('email_subject', instance.description)
     url = instance.data.get('url', '')
     description = instance.description
     if url:

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -162,7 +162,7 @@ class TestNotifications(TestOrganizationMixin, TestCase):
         self.notification_options.pop('email_subject')
         self._create_notification()
         n = notification_queryset.first()
-        self.assertEqual(mail.outbox[0].subject, n.description[0:24])
+        self.assertEqual(mail.outbox[0].subject, n.description)
 
     def test_handler_optional_tag(self):
         operator = self._create_operator()


### PR DESCRIPTION
This PR serves as a quick patch for truncated email subject.
Fixes #24 

_P.S. : These changes were already made in #19_