### PR TITLE
[ui] Fixed notification badge for 99+ notifications #28

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,7 +296,7 @@ An example usage has been shown below.
 .. note::
 
     You can use ``site`` and ``notification`` variables while defining ``message`` and ``email_subject``
-    configuration of notification type. They refer to objects of ``django.contrib.sites.models.Site`
+    configuration of notification type. They refer to objects of ``django.contrib.sites.models.Site``
     and ``openwisp_notifications.models.Notification`` repectively. This allows you to use any of their
     attributes in your configuration.
 

--- a/openwisp_notifications/static/openwisp_notifications/css/notifications.css
+++ b/openwisp_notifications/static/openwisp_notifications/css/notifications.css
@@ -28,8 +28,8 @@
 #openwisp-notifications span {
   position: absolute;
   top: 3px;
-  right: 7px;
-  width: 15px;
+  left: 27px;
+  min-width: 15px;
   height: 15px;
   display: block;
   line-height: 14px;

--- a/openwisp_notifications/templatetags/openwisp_notifications.py
+++ b/openwisp_notifications/templatetags/openwisp_notifications.py
@@ -16,6 +16,7 @@ def get_notifications_count(context):
     count = cache.get(cache_key)
     if count is None:
         count = notifications_unread(context)
+        count = '99+' if count > 99 else count
         cache.set(cache_key, count)
     return count
 

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -56,8 +56,8 @@ class TestAdmin(TestOrganizationMixin, TestCase):
     _url = reverse('admin:openwisp_notifications_notification_changelist')
     _cache_key = Notification.COUNT_CACHE_KEY
 
-    def _expected_output(self, count=0):
-        if count > 0:
+    def _expected_output(self, count=None):
+        if count:
             return '<span>{0}</span>'.format(count)
         return 'id="openwisp-notifications">'
 
@@ -66,11 +66,19 @@ class TestAdmin(TestOrganizationMixin, TestCase):
         self.assertContains(r, self._expected_output())
 
     def test_non_zero_notifications(self):
-        no_of_notifications = 10
-        for _ in range(no_of_notifications):
-            notify.send(**self.notification_options)
-        r = self.client.get(self._url)
-        self.assertContains(r, self._expected_output(no_of_notifications))
+        with self.subTest("Test UI for less than 100 notifications"):
+            no_of_notifications = 10
+            for _ in range(no_of_notifications):
+                notify.send(**self.notification_options)
+            r = self.client.get(self._url)
+            self.assertContains(r, self._expected_output('10'))
+
+        with self.subTest("Test UI for 99+ notifications"):
+            no_of_notifications = 100
+            for _ in range(no_of_notifications):
+                notify.send(**self.notification_options)
+            r = self.client.get(self._url)
+            self.assertContains(r, self._expected_output('99+'))
 
     def test_cached_value(self):
         self.client.get(self._url)


### PR DESCRIPTION
Closes #28 
Closes #32 
This might be a better way to follow DRY principle, but I was not sure whether having function inside 
function is desirable. What are your thoughts? 

```
def test_non_zero_notifications(self):
        def test_ui_notification_badge(obj, no_of_notifications):
            for _ in range(no_of_notifications):
                notify.send(**obj.notification_options)
            r = obj.client.get(obj._url)
            obj.assertContains(r, obj._expected_output(str(no_of_notifications)))
        
        with self.subTest("Test UI for less than 100 notifications"):
            test_ui_notification_badge(self, 10)

        with self.subTest("Test UI for 99+ notifications"):
            test_ui_notification_badge(self, 100)
```
Did some testing of UI as well. :smile: 

### Notifications > 99
Desktop
![Screenshot from 2020-06-05 04-45-41](https://user-images.githubusercontent.com/32094433/83820867-6a598b00-a6eb-11ea-9827-2a2eb382108e.png)
Responsive
![Screenshot from 2020-06-05 04-51-29](https://user-images.githubusercontent.com/32094433/83820879-70e80280-a6eb-11ea-9b9a-01a846c0f9b8.png)

### Notifications < 100
Desktop
![Screenshot from 2020-06-05 04-53-34](https://user-images.githubusercontent.com/32094433/83820909-89581d00-a6eb-11ea-89c4-d337f1c25ab7.png)
Responsive
![Screenshot from 2020-06-05 04-53-44](https://user-images.githubusercontent.com/32094433/83820925-8fe69480-a6eb-11ea-8f72-509f12e5193e.png)

### Single digit notification
Desktop
![Screenshot from 2020-06-05 04-54-06](https://user-images.githubusercontent.com/32094433/83821155-a8ef4580-a6eb-11ea-81b1-4b5336b87493.png)
Responsive
![Screenshot from 2020-06-05 04-54-16](https://user-images.githubusercontent.com/32094433/83820952-937a1b80-a6eb-11ea-8100-60194346d0cf.png)

