### PR TITLE
[models] Fixed bug for missing related object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: python
 cache: pip
 dist: bionic
 
-addons:
-  apt:
-    packages:
-      - sqlite3
-      - gdal-bin
-
 python:
   - "3.6"
   - "3.7"
@@ -15,6 +9,16 @@ python:
 env:
   - DJANGO="django>=2.2,<3.0"
   - DJANGO="django>=3.0,<3.1"
+
+addons:
+  apt:
+    packages:
+      - sqlite3
+      - gdal-bin
+
+services:
+  - docker
+  - redis-server
 
 branches:
   only:

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,40 @@ Setup (integrate into an existing Django project)
         'openwisp_notifications',
      ]
 
+Configure caching (you may use a different cache storage if you want):
+
+.. code-block:: python
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': 'redis://localhost/5',
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            }
+        }
+    }
+
+    SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+    SESSION_CACHE_ALIAS = 'default'
+
+Configure celery:
+
+.. code-block:: python
+
+    # here we show how to configure celery with Redis but you can
+    # use other brokers if you want, consult the celery docs
+    CELERY_BROKER_URL = 'redis://localhost/1'
+
+    INSTALLED_APPS.append('djcelery_email')
+    EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+
+If you decide to use redis (as shown in these examples), install the requierd python packages:
+
+.. code-block:: shell
+
+    pip install redis django-redis
+
 Sending notifications
 ---------------------
 
@@ -351,6 +385,14 @@ publicly accessible from the internet. Otherwise, the logo may not be displayed 
 Installing for development
 --------------------------
 
+We use Redis as celery broker (you can use a different broker if you want).
+The recommended way for development is running it using Docker so you will need to
+`install docker and docker-compose <https://docs.docker.com/engine/install/>`_ beforehand.
+
+In case you prefer not to use Docker you can
+`install Redis from your repositories <https://redis.io/download>`_, but keep in mind that
+the version packaged by your distribution may be different.
+
 Install SQLite:
 
 .. code-block:: shell
@@ -371,6 +413,12 @@ Install test requirements:
 
     pip install -r requirements-test.txt
 
+Start Redis using docker-compose:
+
+.. code-block:: shell
+
+    docker-compose up -d
+
 Create a database:
 
 .. code-block:: shell
@@ -386,6 +434,13 @@ Launch the development server:
     ./manage.py runserver
 
 You can access the admin interface at http://127.0.0.1:8000/admin/.
+
+Run celery  worker (separate terminal window is needed):
+
+.. code-block:: shell
+
+    # (cd tests)
+    celery -A openwisp2 worker -l info
 
 Run tests with:
 
@@ -623,7 +678,26 @@ file in the test project.
 For more information about URL configuration in django, please refer to the
 `"URL dispatcher" section in the django documentation <https://docs.djangoproject.com/en/dev/topics/http/urls/>`_.
 
-12. Register Template Tags
+12. Create celery.py
+~~~~~~~~~~~~~~~~~~~~
+
+Please refer to the `celery.py <https://github.com/openwisp/openwisp-notifications/blob/master/tests/openwisp2/celery.py>`_
+file in the test project.
+
+For more information about the usage of celery in django, please refer to the
+`"First steps with Django" section in the celery documentation <https://docs.celeryproject.org/en/master/django/first-steps-with-django.html>`_.
+
+13. Import Celery Tasks
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the following in your settings.py to import celery tasks from ``openwisp_notifications`` app.
+
+.. code-block:: python
+
+    CELERY_IMPORTS = ('openwisp_notifications.tasks',)
+
+
+14. Register Template Tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you need to use template tags of *openwisp_notifications*, you will need to register as the, shown in
@@ -633,7 +707,7 @@ If you need to use template tags of *openwisp_notifications*, you will need to r
 For more information about template tags in django, please refer to the
 `"Custom template tags and filters" section in the django documentation <https://docs.djangoproject.com/en/dev/topics/http/urls/>`_.
 
-13. Add Base Template for Admin
+15. Add Base Template for Admin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Please refer to the `"templates/admin/base.html" in sample_notifications
@@ -643,7 +717,7 @@ For more information about customizing admin templates in django, please refer t
 `"Overriding admin templates" section in the django documentation
 <https://docs.djangoproject.com/en/3.0/ref/contrib/admin/#overriding-admin-templates>`_.
 
-14. Import the automated tests
+16. Import the automated tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When developing a custom application based on this module, it's a good idea to import and run the base tests

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Configure caching (you may use a different cache storage if you want):
     CACHES = {
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION': 'redis://localhost/5',
+            'LOCATION': 'redis://localhost/0',
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             }
@@ -99,10 +99,7 @@ Configure celery:
     # use other brokers if you want, consult the celery docs
     CELERY_BROKER_URL = 'redis://localhost/1'
 
-    INSTALLED_APPS.append('djcelery_email')
-    EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
-
-If you decide to use redis (as shown in these examples), install the requierd python packages:
+If you decide to use redis (as shown in these examples), make sure the python dependencies are installed in your system:
 
 .. code-block:: shell
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  redis:
+    image: redis:5.0-alpine
+    ports:
+      - "6379:6379"
+    entrypoint: redis-server --appendonly yes

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -1,0 +1,27 @@
+from celery import shared_task
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from openwisp_notifications.swapper import load_model
+
+Notification = load_model('Notification')
+
+
+@shared_task
+def delete_obsolete_notifications(instance_app_label, instance_model, instance_id):
+    """
+    Delete notifications having 'instance' as actor, action or target object.
+    """
+    instance_content_type = ContentType.objects.get_by_natural_key(
+        instance_app_label, instance_model
+    )
+    where = (
+        Q(actor_content_type=instance_content_type)
+        | Q(action_object_content_type=instance_content_type)
+        | Q(target_content_type=instance_content_type)
+    )
+    where = where & (
+        Q(actor_object_id=instance_id)
+        | Q(action_object_object_id=instance_id)
+        | Q(target_object_id=instance_id)
+    )
+    Notification.objects.filter(where).delete()

--- a/openwisp_notifications/utils.py
+++ b/openwisp_notifications/utils.py
@@ -3,6 +3,10 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
 
+class NotificationException(Exception):
+    pass
+
+
 def _get_object_link(obj, field, html=True, url_only=False, absolute_url=False):
     site = Site.objects.get_current()
     content_type = getattr(obj, f'{field}_content_type', None)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 coveralls
+django-redis
 openwisp-utils[qa]>=0.4.1
+redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django-celery-email>=3.0.0,<3.1
 django-notifications-hq>=1.6,<1.7
 openwisp-users>=0.2.0,<0.3.0
 # TODO: enable when openwisp-utils 0.5 is released

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+django-celery-email>=3.0.0,<3.1
 django-notifications-hq>=1.6,<1.7
 openwisp-users>=0.2.0,<0.3.0
 # TODO: enable when openwisp-utils 0.5 is released

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openwisp-users>=0.2.0,<0.3.0
 # openwisp-utils[rest]~=0.5
 swapper~=1.1
 markdown>=3.2,<3.3
+celery~=4.4

--- a/tests/openwisp2/__init__.py
+++ b/tests/openwisp2/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/tests/openwisp2/celery.py
+++ b/tests/openwisp2/celery.py
@@ -3,17 +3,9 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 from celery import Celery
-from django.conf import settings
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp_notifications.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp2.settings')
 
-app = Celery('openwisp_notifications')
+app = Celery('openwisp2')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
-app.config_from_object('django.conf:settings', namespace='CELERY')
-
-# don't ask me why this needs to be done
-# but without it celery-beat won't work
-# TODO: fixme
-if hasattr(settings, 'CELERYBEAT_SCHEDULE'):
-    app.conf.CELERYBEAT_SCHEDULE = settings.CELERYBEAT_SCHEDULE

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -136,7 +136,7 @@ if not TESTING:
     LOGGING.update({'root': {'level': 'INFO', 'handlers': ['console']}})
 
 if not TESTING:
-    CELERY_BROKER_URL = 'redis://localhost/1'
+    CELERY_BROKER_URL = 'redis://localhost/6'
 else:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
Closes #43 

Caveats:

1. Receiver is triggered for all objects and makes two queries to database each time.
2. If number of notifications is huge, than this can take time. 

I thought of offloading this work to a celery worker, but it will not be possible as related objects may  already get deleted even before celery worker can complete this task. And we will get an error at assigning description. 

If we strictly opt for deleting notifications, that task can be offloaded to celery workers easily.

We are preserving information by not deleting notifications and leaving it to user when to delete such notifications. 

![Hnet-image](https://user-images.githubusercontent.com/32094433/84451682-5b398680-ac71-11ea-9261-10b48781d7d5.gif)
