### PR TITLE
[fix] Reduced database queries for notifications #47

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,7 @@ Additional ``notify`` keyword arguments
 |                     | not be added to the email text.                                             |
 +---------------------+-----------------------------------------------------------------------------+
 |       ``type``      | Set values of other parameters based on predefined setting                  |
-|                     | ``OPENWISP_NOTIFICATION_TYPES``                                             |
+|                     | ``OPENWISP_NOTIFICATIONS_TYPES``                                            |
 |                     |                                                                             |
 |                     | Defaults to **None** meaning you need to provide other arguments.           |
 +---------------------+-----------------------------------------------------------------------------+
@@ -399,8 +399,8 @@ registered.
 Settings
 --------
 
-``OPENWISP_NOTIFICATION_HTML_EMAIL``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``OPENWISP_NOTIFICATIONS_HTML_EMAIL``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-----------+------------+
 |   type    |  ``bool``  |
@@ -412,8 +412,8 @@ If ``True``, attaches markdown rendered HTML of notification message in email no
 If ``False``, HTML rendering of notification message will be disabled and a plain
 text email is sent.
 
-``OPENWISP_NOTIFICATION_EMAIL_TEMPLATE``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``OPENWISP_NOTIFICATIONS_EMAIL_TEMPLATE``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-----------+--------------------------------------------------+
 |   type    |  ``str``                                         |
@@ -452,8 +452,8 @@ See `openwisp_notifications/email_template.html <https://github.com/pandafy/open
 master/openwisp_notifications/templates/openwisp_notifications/email_template.html>`_
 for reference implementation.
 
-``OPENWISP_NOTIFICATION_EMAIL_LOGO``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``OPENWISP_NOTIFICATIONS_EMAIL_LOGO``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-----------+----------------------------------------------------------------------------------------------+
 |   type    |  ``str``                                                                                     |

--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,16 @@ Additional ``notify`` keyword arguments
 |                     | Defaults to **None** meaning you need to provide other arguments.           |
 +---------------------+-----------------------------------------------------------------------------+
 
+Notification Cache
+------------------
+
+In a typical OpenWISP installation, ``actor``, ``action_object`` and ``target`` objects are same
+for a number of notifications. To optimize database queries, these objects are cached using
+`Django’s cache framework <https://docs.djangoproject.com/en/3.0/topics/cache/>`_.
+The cached values are updated automatically to reflect actual data from database. You can control
+the duration of caching these objects using
+`OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT setting <#OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT>`_
+
 Notification Types
 ------------------
 
@@ -518,6 +528,19 @@ Provide an absolute or relative path(hosted on your webserver) to audio file as 
 .. code-block:: python
 
     OPENWISP_NOTIFICATIONS_SOUND = '/static/your-appname/audio/notification.mp3'
+
+``OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+------------------------------------+
+|   type    |  ``int``                           |
++-----------+------------------------------------+
+|  default  |  ``172800`` `(2 days, in seconds)` |
++-----------+------------------------------------+
+
+It sets the number of seconds the notification contents should be stored in the cache.
+If you want cached notification content to never expire, then set it to ``None``.
+Set it to ``0`` if you don't want to store notification contents in cache at all.
 
 REST API
 --------

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -76,8 +76,7 @@ def notify_handler(**kwargs):
     for recipient in recipients:
         newnotify = Notification(
             recipient=recipient,
-            actor_content_type=ContentType.objects.get_for_model(actor),
-            actor_object_id=actor.pk,
+            actor=actor,
             verb=str(verb),
             public=public,
             description=description,
@@ -164,7 +163,7 @@ def send_email_notification(sender, instance, created, **kwargs):
 )
 def clear_notification_cache(sender, instance, **kwargs):
     try:
-        Notification.invalidate_cache(instance.recipient)
+        Notification.invalidate_unread_cache(instance.recipient)
     except AttributeError:
         return
     # Reload notification only if notification is created or deleleted

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -141,11 +141,11 @@ def send_email_notification(sender, instance, created, **kwargs):
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[instance.recipient.email],
     )
-    if app_settings.OPENWISP_NOTIFICATION_HTML_EMAIL:
+    if app_settings.OPENWISP_NOTIFICATIONS_HTML_EMAIL:
         html_message = render_to_string(
-            app_settings.OPENWISP_NOTIFICATION_EMAIL_TEMPLATE,
+            app_settings.OPENWISP_NOTIFICATIONS_EMAIL_TEMPLATE,
             context=dict(
-                OPENWISP_NOTIFICATION_EMAIL_LOGO=app_settings.OPENWISP_NOTIFICATION_EMAIL_LOGO,
+                OPENWISP_NOTIFICATIONS_EMAIL_LOGO=app_settings.OPENWISP_NOTIFICATIONS_EMAIL_LOGO,
                 notification=instance,
                 target_url=target_url,
             ),

--- a/openwisp_notifications/settings.py
+++ b/openwisp_notifications/settings.py
@@ -3,21 +3,21 @@ from notifications.settings import CONFIG_DEFAULTS
 
 CONFIG_DEFAULTS.update({'USE_JSONFIELD': True})
 
-OPENWISP_NOTIFICATION_EMAIL_TEMPLATE = getattr(
+OPENWISP_NOTIFICATIONS_EMAIL_TEMPLATE = getattr(
     settings,
-    'OPENWISP_NOTIFICATION_EMAIL_TEMPLATE',
+    'OPENWISP_NOTIFICATIONS_EMAIL_TEMPLATE',
     'openwisp_notifications/email_template.html',
 )
 
-OPENWISP_NOTIFICATION_EMAIL_LOGO = getattr(
+OPENWISP_NOTIFICATIONS_EMAIL_LOGO = getattr(
     settings,
-    'OPENWISP_NOTIFICATION_EMAIL_LOGO',
+    'OPENWISP_NOTIFICATIONS_EMAIL_LOGO',
     'https://raw.githubusercontent.com/openwisp/openwisp-notifications/master/openwisp_notifications/'
     'static/openwisp_notifications/images/openwisp-logo.png',
 )
 
-OPENWISP_NOTIFICATION_HTML_EMAIL = getattr(
-    settings, 'OPENWISP_NOTIFICATION_HTML_EMAIL', True
+OPENWISP_NOTIFICATIONS_HTML_EMAIL = getattr(
+    settings, 'OPENWISP_NOTIFICATIONS_HTML_EMAIL', True
 )
 
 OPENWISP_NOTIFICATIONS_HOST = getattr(settings, 'OPENWISP_NOTIFICATIONS_HOST', None)

--- a/openwisp_notifications/settings.py
+++ b/openwisp_notifications/settings.py
@@ -27,6 +27,10 @@ OPENWISP_NOTIFICATIONS_SOUND = getattr(
     '/static/openwisp_notifications/audio/notification_bell.mp3',
 )
 
+OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT = getattr(
+    settings, 'OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT', 2 * 24 * 60 * 60
+)
+
 
 def get_config():
     user_config = getattr(settings, 'OPENWISP_NOTIFICATIONS_CONFIG', {})

--- a/openwisp_notifications/templates/openwisp_notifications/email_template.html
+++ b/openwisp_notifications/templates/openwisp_notifications/email_template.html
@@ -123,7 +123,7 @@
             Large screen devices' notification header
           {% endcomment %}
           <tr class="notification-header">
-            <th><img src="{{ OPENWISP_NOTIFICATION_EMAIL_LOGO }}" alt="Logo" id="logo" class="logo"></th>
+            <th><img src="{{ OPENWISP_NOTIFICATIONS_EMAIL_LOGO }}" alt="Logo" id="logo" class="logo"></th>
             <th class="notification-subject">{{ notification.email_subject }}</th>
           </tr>
           {% comment %}
@@ -131,7 +131,7 @@
             Mobile devices' notification header
           {% endcomment %}
           <tr class="m-notification-header">
-            <th><img src="{{ OPENWISP_NOTIFICATION_EMAIL_LOGO }}" alt="Logo" id="logo" class="logo"></th>
+            <th><img src="{{ OPENWISP_NOTIFICATIONS_EMAIL_LOGO }}" alt="Logo" id="logo" class="logo"></th>
           </tr>
           <tr class="m-notification-header">
             <th class="notification-subject">{{ notification.email_subject }}</th>

--- a/openwisp_notifications/templatetags/notification_tags.py
+++ b/openwisp_notifications/templatetags/notification_tags.py
@@ -15,7 +15,7 @@ register = Library()
 
 def get_notifications_count(context):
     user_pk = context['user'].is_authenticated and context['user'].pk
-    cache_key = Notification.COUNT_CACHE_KEY.format(user_pk)
+    cache_key = Notification.count_cache_key(user_pk)
     count = cache.get(cache_key)
     if count is None:
         count = base_notification_unread(context)

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -59,10 +59,6 @@ class TestAdmin(TestOrganizationMixin, TestCase):
     def _url(self):
         return reverse('admin:index')
 
-    @property
-    def _cache_key(self):
-        return Notification.COUNT_CACHE_KEY
-
     def _expected_output(self, count=None):
         if count:
             return '<span id="ow-notification-count">{0}</span>'.format(count)
@@ -89,7 +85,7 @@ class TestAdmin(TestOrganizationMixin, TestCase):
 
     def test_cached_value(self):
         self.client.get(self._url)
-        cache_key = self._cache_key.format(self.admin.pk)
+        cache_key = Notification.count_cache_key(self.admin.pk)
         self.assertEqual(cache.get(cache_key), 0)
         return cache_key
 

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -411,7 +411,7 @@ class TestNotifications(TestOrganizationMixin, TestCase):
             )
             self.assertEqual(content_type, 'text/html')
             self.assertIn(
-                f'<img src="{app_settings.OPENWISP_NOTIFICATION_EMAIL_LOGO}"'
+                f'<img src="{app_settings.OPENWISP_NOTIFICATIONS_EMAIL_LOGO}"'
                 ' alt="Logo" id="logo" class="logo">',
                 html_message,
             )
@@ -506,7 +506,7 @@ class TestNotifications(TestOrganizationMixin, TestCase):
         self.assertEqual(len(mail.outbox), 0)
         unregister_notification_type('test_type')
 
-    @patch.object(app_settings, 'OPENWISP_NOTIFICATION_HTML_EMAIL', False)
+    @patch.object(app_settings, 'OPENWISP_NOTIFICATIONS_HTML_EMAIL', False)
     def test_no_html_email(self, *args):
         operator = self._create_operator()
         self.notification_options.update(

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1,16 +1,17 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-import openwisp_notifications.settings as app_settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
+from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.template import TemplateDoesNotExist
 from django.test import TestCase
 from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.timesince import timesince
+from openwisp_notifications import settings as app_settings
 from openwisp_notifications.handlers import notify_handler
 from openwisp_notifications.signals import notify
 from openwisp_notifications.swapper import load_model
@@ -521,3 +522,36 @@ class TestNotifications(TestOrganizationMixin, TestCase):
         )
         self.assertEqual(email.subject, '[example.com] Default Notification Subject')
         self.assertFalse(email.alternatives)
+
+    def test_related_objects_database_query(self):
+        operator = self._get_operator()
+        self.notification_options.update(
+            {'action_object': operator, 'target': operator}
+        )
+        self._create_notification()
+        with self.assertNumQueries(2):
+            # 2 queries since admin is already chached
+            n = notification_queryset.first()
+            self.assertEqual(n.actor, self.admin)
+            self.assertEqual(n.action_object, operator)
+            self.assertEqual(n.target, operator)
+
+    @patch.object(app_settings, 'OPENWISP_NOTIFICATIONS_CACHE_TIMEOUT', 0)
+    def test_notification_cache_timeout(self):
+        # Timeout=0 means value is not cached
+        operator = self._get_operator()
+        self.notification_options.update(
+            {'action_object': operator, 'target': operator}
+        )
+        self._create_notification()
+
+        n = notification_queryset.first()
+        with self.assertNumQueries(3):
+            # Expect database query for each operation, nothing is cached
+            self.assertEqual(n.actor, self.admin)
+            self.assertEqual(n.action_object, operator)
+            self.assertEqual(n.target, operator)
+
+        # Test cache is not set
+        self.assertIsNone(cache.get(Notification._cache_key(self.admin.pk)))
+        self.assertIsNone(cache.get(Notification._cache_key(operator.pk)))

--- a/openwisp_notifications/utils.py
+++ b/openwisp_notifications/utils.py
@@ -6,13 +6,12 @@ class NotificationException(Exception):
     pass
 
 
-def _get_object_link(obj, field, url_only=False, absolute_url=False):
-    content_type = getattr(obj, f'{field}_content_type', None)
-    object_id = getattr(obj, f'{field}_object_id', None)
+def _get_object_link(obj, field, url_only=False, absolute_url=False, *args, **kwargs):
+    related_obj = getattr(obj, field)
     try:
         url = reverse(
-            f'admin:{content_type.app_label}_{content_type.model}_change',
-            args=[object_id],
+            f'admin:{related_obj._meta.app_label}_{related_obj._meta.model_name}_change',
+            args=[related_obj.id],
         )
         if absolute_url:
             url = _get_absolute_url(url)


### PR DESCRIPTION
Added caching for related objects to limit database queries.
Closes #47 

For 18 notifications, 58 database queries were being made each time earlier on Notification Admin. After caching they are down to 4 . :smile: 

**Before**
![Screenshot from 2020-07-14 13-34-48](https://user-images.githubusercontent.com/32094433/87435452-63d30300-c609-11ea-9c05-5957873a8a38.png)

**After**
![Screenshot from 2020-07-14 13-35-23](https://user-images.githubusercontent.com/32094433/87435447-62093f80-c609-11ea-9402-8885a8976161.png)
