### PR TITLE
[feature] Added scheduled deletion of old notifications

### DIFF
--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -2,6 +2,8 @@ from celery import shared_task
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from openwisp_notifications.swapper import load_model
+from django.util import timezone
+from datetime import timedelta
 
 Notification = load_model('Notification')
 
@@ -23,5 +25,16 @@ def delete_obsolete_notifications(instance_app_label, instance_model, instance_i
         Q(actor_object_id=instance_id)
         | Q(action_object_object_id=instance_id)
         | Q(target_object_id=instance_id)
+    )
+    Notification.objects.filter(where).delete()
+
+
+@shared_task
+def delete_expired_notifications(threshold_expiry_days):
+    """
+    Delete notifications having 'timestamp' more than 90 days, task scheduled for every Monday 2:00 a.m.
+    """
+    where = (
+        Q(timestamp=timezone.now() - timedelta(days=threshold_expiry_days))
     )
     Notification.objects.filter(where).delete()

--- a/tests/openwisp2/celery.py
+++ b/tests/openwisp2/celery.py
@@ -3,9 +3,21 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 from celery import Celery
+from celery.schedules import crontab
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp2.settings')
 
 app = Celery('openwisp2')
 app.config_from_object('django.conf:settings', namespace='CELERY')
+"""
+Delete notifications having 'timestamp' more than 90 days, task scheduled for every Monday 2:00 a.m.
+"""
+app.conf.beat_schedule = {
+    'delete-expired-notifications-every-monday': {
+        'task': 'tasks.add',
+        'schedule': crontab(hour=2, day_of_week=1),
+        'args': (90,)
+    },
+}
+app.conf.timezone = 'UTC'
 app.autodiscover_tasks()


### PR DESCRIPTION
#6 Closes
Added a scheduled task to delete notifications older than 90 days using celery's period task. I have added the app configuration code in [tests](https://github.com/openwisp/openwisp-notifications/tree/master/tests) project.