### PR TITLE
[chores] Made URL namespace consistent (2)

### DIFF
--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -20,7 +20,7 @@ NOT_FOUND_ERROR = ErrorDetail(string='Not found.', code='not_found')
 
 
 class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
-    app_label = 'notifications'
+    url_namespace = 'notifications'
 
     def setUp(self):
         self.admin = self._get_admin(self)
@@ -28,7 +28,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
     def test_list_notification_api(self):
         number_of_notifications = 11
-        url = reverse(f'{self.app_label}:notifications_list')
+        url = reverse(f'{self.url_namespace}:notifications_list')
         for _ in range(number_of_notifications):
             notify.send(sender=self.admin, type='default', target=self.admin)
 
@@ -93,7 +93,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             )
 
     def test_list_notification_filtering(self):
-        url = reverse(f'{self.app_label}:notifications_list')
+        url = reverse(f'{self.url_namespace}:notifications_list')
         notify.send(sender=self.admin, type='default', target=self.admin)
         notify.send(sender=self.admin, type='default', target=self.admin)
         # Mark one notification as read
@@ -128,7 +128,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         for _ in range(number_of_notifications):
             notify.send(sender=self.admin, type='default', target=self.admin)
 
-        url = reverse(f'{self.app_label}:notifications_read_all')
+        url = reverse(f'{self.url_namespace}:notifications_read_all')
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.data)
@@ -142,7 +142,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test for non-existing notification'):
             url = reverse(
-                f'{self.app_label}:notification_detail', kwargs={'pk': uuid.uuid4()}
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': uuid.uuid4()}
             )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
@@ -151,7 +151,9 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             )
 
         with self.subTest('Test retrieving details for existing notification'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             data = response.data
@@ -166,7 +168,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test for non-existing notification'):
             url = reverse(
-                f'{self.app_label}:notification_detail', kwargs={'pk': uuid.uuid4()}
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': uuid.uuid4()}
             )
             response = self.client.patch(url)
             self.assertEqual(response.status_code, 404)
@@ -176,7 +178,9 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test for existing notificaton'):
             self.assertTrue(n.unread)
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.patch(url)
             self.assertEqual(response.status_code, 200)
             self.assertIsNone(response.data)
@@ -189,7 +193,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test for non-existing notification'):
             url = reverse(
-                f'{self.app_label}:notification_detail', kwargs={'pk': uuid.uuid4()}
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': uuid.uuid4()}
             )
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 404)
@@ -198,7 +202,9 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             )
 
         with self.subTest('Test for valid notificaton'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 204)
             self.assertIsNone(response.data)
@@ -215,14 +221,14 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         self.client.logout()
 
         with self.subTest('Test for list notifications API'):
-            url = reverse(f'{self.app_label}:notifications_list')
+            url = reverse(f'{self.url_namespace}:notifications_list')
             response = self.client.get(url)
             self.assertEqual(response.status_code, 401)
             self.assertEqual(response.data, exp_response_data)
 
         with self.subTest('Test for rnotification detail API'):
             url = reverse(
-                f'{self.app_label}:notification_detail', kwargs={'pk': uuid.uuid4()}
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': uuid.uuid4()}
             )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 401)
@@ -235,31 +241,37 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         token = self._obtain_auth_token(username='admin', password='tester')
 
         with self.subTest('Test listing all notifications'):
-            url = reverse(f'{self.app_label}:notifications_list')
+            url = reverse(f'{self.url_namespace}:notifications_list')
             response = self.client.get(url, HTTP_AUTHORIZATION=f'Bearer {token}')
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.data['results']), 1)
 
         with self.subTest('Test marking all notifications as read'):
-            url = reverse(f'{self.app_label}:notifications_read_all')
+            url = reverse(f'{self.url_namespace}:notifications_read_all')
             response = self.client.post(url, HTTP_AUTHORIZATION=f'Bearer {token}')
             self.assertEqual(response.status_code, 200)
             self.assertIsNone(response.data)
 
         with self.subTest('Test retrieving notification'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.get(url, HTTP_AUTHORIZATION=f'Bearer {token}')
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['id'], str(n.id))
 
         with self.subTest('Test marking a notification as read'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.patch(url, HTTP_AUTHORIZATION=f'Bearer {token}')
             self.assertEqual(response.status_code, 200)
             self.assertIsNone(response.data)
 
         with self.subTest('Test deleting notification'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.delete(url, HTTP_AUTHORIZATION=f'Bearer {token}')
             self.assertEqual(response.status_code, 204)
             self.assertIsNone(response.data)
@@ -273,7 +285,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         self.client.force_login(joe)
 
         with self.subTest('Test listing all notifications'):
-            url = reverse(f'{self.app_label}:notifications_list')
+            url = reverse(f'{self.url_namespace}:notifications_list')
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 0)
@@ -281,7 +293,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             self.assertEqual(response.data['next'], None)
 
         with self.subTest('Test marking all notifications as read'):
-            url = reverse(f'{self.app_label}:notifications_read_all')
+            url = reverse(f'{self.url_namespace}:notifications_read_all')
             response = self.client.post(url)
             self.assertEqual(response.status_code, 200)
             self.assertIsNone(response.data)
@@ -290,13 +302,17 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             self.assertTrue(n.unread)
 
         with self.subTest('Test retrieving notification'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
 
         with self.subTest('Test marking a notification as read'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.patch(url)
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
@@ -305,7 +321,9 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
             self.assertTrue(n.unread)
 
         with self.subTest('Test deleting notification'):
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
@@ -314,7 +332,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
     def test_list_view_notification_cache(self):
         number_of_notifications = 5
-        url = reverse(f'{self.app_label}:notifications_list')
+        url = reverse(f'{self.url_namespace}:notifications_list')
         url = f'{url}?page_size={number_of_notifications}'
         operator = self._get_operator()
         for _ in range(number_of_notifications):
@@ -338,7 +356,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         with self.subTest('Test list notifications'):
             notify.send(sender=self.admin, type='default')
             notify.send(sender=self.admin, type='test_type')
-            url = reverse(f'{self.app_label}:notifications_list')
+            url = reverse(f'{self.url_namespace}:notifications_list')
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 1)
@@ -350,7 +368,9 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test retrieve notification'):
             [(_, [n])] = notify.send(sender=self.admin, type='test_type')
-            url = reverse(f'{self.app_label}:notification_detail', kwargs={'pk': n.id})
+            url = reverse(
+                f'{self.url_namespace}:notification_detail', kwargs={'pk': n.id}
+            )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
@@ -389,7 +409,7 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
         self.assertIsNone(cache.get(cache_key))
 
         with self.subTest('Test list notifications'):
-            url = reverse(f'{self.app_label}:notifications_list')
+            url = reverse(f'{self.url_namespace}:notifications_list')
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 1)
@@ -397,7 +417,8 @@ class TestNotificationApi(TestCase, TestOrganizationMixin, AuthenticationMixin):
 
         with self.subTest('Test retrieve notification'):
             url = reverse(
-                f'{self.app_label}:notification_detail', kwargs={'pk': notification.id}
+                f'{self.url_namespace}:notification_detail',
+                kwargs={'pk': notification.id},
             )
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -36,8 +36,6 @@ ten_minutes_ago = start_time - timedelta(minutes=10)
 
 
 class TestNotifications(TestOrganizationMixin, TestCase):
-    app_label = 'openwisp_notifications'
-
     def setUp(self):
         self.admin = self._create_admin()
         self.notification_options = dict(

--- a/tests/openwisp2/sample_notifications/tests/test_django.py
+++ b/tests/openwisp2/sample_notifications/tests/test_django.py
@@ -15,8 +15,6 @@ class TestAdmin(BaseTestAdmin):
 
 
 class TestNotifications(BaseTestNotifications):
-    app_label = 'sample_notifications'
-
     # Used only for testing openwisp-notifications
     def test_test_app_object_created_notification(self):
         from openwisp_users.models import OrganizationUser
@@ -38,7 +36,7 @@ class TestNotifications(BaseTestNotifications):
 
 
 class TestNotificationAPI(BaseTestNotificationApi):
-    app_label = 'sample_notifications'
+    pass
 
 
 del BaseTestAdmin

--- a/tests/openwisp2/urls.py
+++ b/tests/openwisp2/urls.py
@@ -3,7 +3,6 @@ import os
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
-from openwisp_notifications.urls import get_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -16,15 +15,14 @@ if os.environ.get('SAMPLE_APP', False):
     # Load custom api views:
     # This should be done when you are extending the app and modifying the API
     # views in your extended application.
+    from openwisp_notifications.urls import get_urls
+
     from .sample_notifications import views as api_views
 
     urlpatterns += [
         path(
             '',
-            include(
-                (get_urls(api_views), 'sample_notifications'),
-                namespace='sample_notifications',
-            ),
+            include((get_urls(api_views), 'notifications'), namespace='notifications'),
         )
     ]
 else:
@@ -32,10 +30,7 @@ else:
     # This can be used when you are extending the app but not making
     # any changes in the API views.
     urlpatterns += [
-        path(
-            '',
-            include('openwisp_notifications.urls', namespace='openwisp_notifications'),
-        )
+        path('', include('openwisp_notifications.urls', namespace='notifications'))
     ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
We have to force users to use the same URL namespace if we want the software to work as expected also when extended.
