### PR TITLE
[feature] Allow passing extra data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -396,6 +396,43 @@ An example usage is shown below.
 **Note**: It will raise ``ImproperlyConfigured`` exception if the concerned notification type is not
 registered.
 
+Passing extra data to notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If needed, additional data, not known beforehand, can be included in the notification message.
+
+A perfect example for this case is an error notification, the error message will vary
+depending on what has happened, so we cannot know until the notification is generated.
+
+Here's how to do it:
+
+.. code-block:: python
+
+    from openwisp_notifications.types import register_notification_type
+
+    register_notification_type('error_type', {
+        'verbose_name': 'Error',
+        'level': 'error',
+        'verb': 'error',
+        'message': 'Error: {error}',
+        'email_subject': 'Error subject: {error}',
+    })
+
+Then in the application code:
+
+.. code-block:: python
+
+    from openwisp_notifications.signals import notify
+
+    try:
+        operation_which_can_fail()
+    except Exception as error:
+        notify.send(
+            type='error_type',
+            sender=sender,
+            error=str(error)
+        )
+
 Settings
 --------
 

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -82,8 +82,9 @@ class AbstractNotification(UUIDModel, BaseNotifcation):
 
             config = get_notification_configuration(self.type)
             try:
+                data = self.data or {}
                 if 'message' in config:
-                    md_text = config['message'].format(notification=self)
+                    md_text = config['message'].format(notification=self, **data)
                 else:
                     md_text = render_to_string(
                         config['message_template'], context=dict(notification=self)
@@ -107,8 +108,9 @@ class AbstractNotification(UUIDModel, BaseNotifcation):
         if self.type:
             try:
                 config = get_notification_configuration(self.type)
+                data = self.data or {}
                 return config['email_subject'].format(
-                    site=Site.objects.get_current(), notification=self
+                    site=Site.objects.get_current(), notification=self, **data
                 )
             except (AttributeError, KeyError) as e:
                 from openwisp_notifications.tasks import delete_notification

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -73,9 +73,9 @@ def notify_handler(**kwargs):
         (kwargs.pop(opt, None), opt) for opt in ('target', 'action_object')
     ]
 
-    new_notifications = []
+    notification_list = []
     for recipient in recipients:
-        newnotify = Notification(
+        notification = Notification(
             recipient=recipient,
             actor=actor,
             verb=str(verb),
@@ -89,18 +89,18 @@ def notify_handler(**kwargs):
         # Set optional objects
         for obj, opt in optional_objs:
             if obj is not None:
-                setattr(newnotify, '%s_object_id' % opt, obj.pk)
+                setattr(notification, '%s_object_id' % opt, obj.pk)
                 setattr(
-                    newnotify,
+                    notification,
                     '%s_content_type' % opt,
                     ContentType.objects.get_for_model(obj),
                 )
         if kwargs and EXTRA_DATA:
-            newnotify.data = kwargs
-        newnotify.save()
-        new_notifications.append(newnotify)
+            notification.data = kwargs
+        notification.save()
+        notification_list.append(notification)
 
-    return new_notifications
+    return notification_list
 
 
 @receiver(post_save, sender=User, dispatch_uid='create_notificationuser')


### PR DESCRIPTION
Ensure extra data is passed when generating `message` and `email_subject`.