### PR TITLE
[fix] Fixed Notification Setting Inline Admin

### DIFF
--- a/openwisp_notifications/base/forms.py
+++ b/openwisp_notifications/base/forms.py
@@ -14,7 +14,10 @@ class NotificationSettingForm(ModelForm):
                 else instance.web_notification,
             }
         super().__init__(*args, **kwargs)
-        self.fields['organization'].choices = self.get_organization_choices()
+        try:
+            self.fields['organization'].choices = self.get_organization_choices()
+        except KeyError:
+            pass
 
     @classmethod
     def get_organization_choices(cls):


### PR DESCRIPTION
Fixed NotificationSettingInlineAdmin for view only access,
i.e. when admin of an organization view UserAdmin of other
users of same organization.