### PR TITLE
[fix] Fixed transparent element of notification widget that covered page #130

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/css/notifications.css
+++ b/openwisp_notifications/static/openwisp-notifications/css/notifications.css
@@ -10,12 +10,11 @@
 .ow-notifications {
   float: right;
   display: block;
-  padding: 0 20px;
+  padding: 1px 20px 0px 20px;
   color: #fff;
   line-height: 40px;
   border: 0 none !important;
   position: relative;
-  bottom: -1px;
   right: -5px;
   margin-left: 10px;
   cursor: pointer;
@@ -301,7 +300,7 @@
     display: block !important;
     line-height: 40px !important;
     position: absolute;
-    top: 43px;
+    top: 42px;
     right: 113px;
   }
 }


### PR DESCRIPTION
The issue was related to div having class ".ow-notifications". It was taking css property bottom=-1 and it was positioned absolutely that's why it was taking complete height. So it made bottom = auto.

Fixes #130