### PR TITLE
[Fix] Added escape key handler for object notification widget #133 

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/object-notifications.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/object-notifications.js
@@ -52,6 +52,14 @@ function initObjectNotificationDropdown($) {
             $('.ow-object-notification-option-container').addClass('ow-hide');
         }
     });
+    $('.ow-object-notification-option-container').on('keyup', '*', function(e){
+        e.stopPropagation();
+        // Hide dropdown on "Escape" key
+        if (e.keyCode == 27){
+            $('.ow-object-notification-option-container').addClass('ow-hide');
+            $('#ow-object-notify').focus();
+        }
+    });
 }
 
 function addObjectNotificationHandlers($) {


### PR DESCRIPTION
The required feature has been added to close the object notification widget on clicking the escape button from the keyboard and focus also returns to the "UNSUBSCRIBE" button.

Fixes #133