### PR TITLE
[fix] Fixed playing sound from multiple windows #137

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/notifications.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/notifications.js
@@ -19,16 +19,13 @@ if (typeof gettext === 'undefined') {
 const owNotificationWindow = {
     // Following functions are used to decide which window has authority
     // to play notification alert sound when multiple windows are open.
-
     init: function init($) {
         // Get authority to play notification sound
         // when current window is in focus
-        $(window).on('focus', function() {owNotificationWindow.set();});
-
+        $(window).on('focus load', function() {owNotificationWindow.set();});
         // Give up the authority to play sound before
         // closing the window
         $(window).on('beforeunload', function() {owNotificationWindow.remove();});
-
         // Get authority to play notification sound when
         // other windows are closed
         $(window).on('storage', function () {


### PR DESCRIPTION
In this solution, I am making use of localStorage in such a way that I am creating different IDs for different tabs and windows of a browser and storing it in the "windows" variable in localStorage. Whenever a notification comes I give access to play the sound to the window/tab whose ID comes first in the "windows" variable. Also removing its ID from the variable on page reload or close.

Fixes #137