### PR TITLE
[fix] Fixed compatible versioning in dependencies and tests for websockets

### DIFF
--- a/openwisp_notifications/tests/test_websockets.py
+++ b/openwisp_notifications/tests/test_websockets.py
@@ -4,9 +4,10 @@ from unittest.mock import patch
 import pytest
 from channels.db import database_sync_to_async
 from channels.testing import WebsocketCommunicator
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from openwisp2.routing import application
+from django.utils.module_loading import import_string
 
 from openwisp_notifications.api.serializers import NotificationListSerializer
 from openwisp_notifications.signals import notify
@@ -51,10 +52,12 @@ def create_object_notification(admin_user):
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 class TestNotificationSockets:
+    application = import_string(getattr(settings, 'ASGI_APPLICATION'))
+
     async def _get_communicator(self, admin_client):
         session_id = admin_client.cookies['sessionid'].value
         communicator = WebsocketCommunicator(
-            application,
+            self.application,
             path='ws/notification/',
             headers=[(b'cookie', f'sessionid={session_id}'.encode('ascii'),)],
         )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
-coveralls~=2.1
+coveralls~=2.1.0
 django-redis~=4.12.1
-django-cors-headers~=3.4
-openwisp-utils[qa]~=0.6
+django-cors-headers~=3.5.0
+openwisp-utils[qa]~=0.6.0
 redis~=3.5.3
 channels_redis~=3.1.0
 pytest-asyncio~=0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-django-notifications-hq>=1.6,<1.7
-channels~=2.4
+django-notifications-hq~=1.6.0
+channels~=2.4.0
 openwisp-users~=0.4.0
-openwisp-utils[rest]~=0.6
-swapper~=1.1
-markdown>=3.2,<3.3
-celery~=4.4
+openwisp-utils[rest]~=0.6.0
+swapper~=1.1.0
+markdown~=3.2.0
+celery~=4.4.0


### PR DESCRIPTION
Bug:
Tests for websockers were importing ASGI application router object from
test project files. This implementation will break if tests are in
another project.

Fix:
Imported the ASGI application router usin string from settings object

Refs https://github.com/openwisp/openwisp-controller/pull/316#discussion_r517749794