### PR TITLE
[deps] Update Celery to version 5 #155

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ openwisp-users~=0.5.0
 openwisp-utils[rest]~=0.7.0
 swapper~=1.1.0
 markdown~=3.2.0
-celery~=4.4.0
+celery~=5.0.5

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -148,7 +148,6 @@ LOGGING = {
         },
         'py.warnings': {'handlers': ['console'], 'propagate': False},
         'celery': {'handlers': ['console'], 'level': 'DEBUG'},
-        'celery.task': {'handlers': ['console'], 'level': 'DEBUG'},
     },
 }
 


### PR DESCRIPTION
The issue required updation to celery version 5. From my findings, it mainly required updating the celery version ```requirements.txt``` to ```celery~=5.0.5```, which has been done in this patch. According to the documentation for celery 5.0, the settings have been changed to lowercase keys. However, in consistence with the rest of the codebase, this patch continues using the uppercase keys for settings with the use of appropriate namespaces. 

Using this [update](https://docs.celeryproject.org/en/stable/whatsnew-5.0.html#removed-deprecated-modules) as a reference, I have removed the ```celery.task``` logger in ```tests/settings.py```. It has been just commented out for the time-being and I wish to take reviewers' opinions about whether or not to completely delete the logger. 

The new CLI [command](https://docs.celeryproject.org/en/stable/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation) to start celery is different from the one used in ```README.rst```. However, using the current invocation in ```README.rst``` still works fine with celery 5. I have not changed it in this patch hence. 

A warning was raised during the dependencies installation process after upgrading to celery 5 mentioning that the current versions of openwisp-users and openwisp-utils require celery version 4. I would wish to have some guidance from the reviewers as how to address this warning. 

Rest of the qa-tests and standard tests work fine after the upgradation to version 5.

Fixes #155 