### PR TITLE
[fix] Fix wss connection error when running on http #160

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,11 +240,6 @@ Configure channel layers (you may use a `different channel layer <https://channe
         },
     }
 
-By default, websockets communicate over ``wss`` protocol. If for some reason, you want them to communicate
-over ``ws`` protocol e.g. while development, you will need to configure ``INTERNAL_IPS`` setting accordingly.
-For more information please refer to
-`"INTERNAL_IPS" section of Django's settings documentation <https://docs.djangoproject.com/en/3.0/ref/settings/#internal-ips>`_.
-
 While development, you can configure it to localhost as shown below:
 
 .. code-block:: python

--- a/openwisp_notifications/templates/admin/base_site.html
+++ b/openwisp_notifications/templates/admin/base_site.html
@@ -37,11 +37,7 @@
       {% else %}
         const notificationApiHost = window.location;
       {% endif %}
-      {% if debug %}
-        const webSocketProtocol = 'ws';
-      {% else %}
-        const webSocketProtocol = 'wss';
-      {% endif %}
+      const webSocketProtocol = notificationApiHost.protocol === 'http:' ? 'ws' : 'wss';
       const notificationSound = new Audio('{{ OPENWISP_NOTIFICATIONS_SOUND | default:"" }}');
       // Create websocket connection
       const notificationSocket = new ReconnectingWebSocket(

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -167,12 +167,6 @@ class TestAdmin(TestOrganizationMixin, TestMultitenantAdminMixin, TestCase):
             response = self.client.get(self._url)
             self.assertContains(response, 'wss')
 
-        with self.subTest('Test in development environment'):
-            with self.settings(DEBUG=True, INTERNAL_IPS=['127.0.0.1']):
-                response = self.client.get(self._url)
-                self.assertNotContains(response, 'wss')
-                self.assertContains(response, 'ws')
-
     def test_notification_setting_inline_read_only_fields(self):
         with self.subTest('Test for superuser'):
             self.assertListEqual(self.ns_inline.get_readonly_fields(su_request), [])


### PR DESCRIPTION
The patch uses the django-loci-module approach in ```base_site.html``` to restrict wss connection attempts while the application is being run over http. The section on IP address additions to ```ALLOWED_HOSTS``` in settings module has been removed from  ```README.rst```. The relevant test in ```test_admin.py``` has been removed.

Fixes #160