### PR TITLE
[bug] Error handling send_email_notification #179

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -171,9 +171,12 @@ def send_email_notification(sender, instance, created, **kwargs):
     # Get email preference of user for this type of notification.
     target_org = getattr(getattr(instance, 'target', None), 'organization_id', None)
     if instance.type and target_org:
-        notification_setting = instance.recipient.notificationsetting_set.get(
-            organization=target_org, type=instance.type
-        )
+        try:
+            notification_setting = instance.recipient.notificationsetting_set.get(
+                organization=target_org, type=instance.type
+            )
+        except NotificationSetting.DoesNotExist:
+            return
         email_preference = notification_setting.email_notification
     else:
         # We can not check email preference if notification type is absent,


### PR DESCRIPTION
Added exception handling in send_email_notification, So if
`notification_setting = instance.recipient.notificationsetting_set.get(
                organization=target_org, type=instance.type
            )` 
NotificationSetting Does Not Exist it will return from function and mail will not be sent.

Closes #179