### PR TITLE
[deps] Updated OpenWISP dependencies to current dev versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1027,7 +1027,7 @@ Install your forked repo:
 
     git clone git://github.com/<your_fork>/openwisp-notifications
     cd openwisp-notifications/
-    python setup.py develop
+    pip install -e .
 
 Install test requirements:
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 coveralls~=2.1.0
 django-redis~=4.12.1
 django-cors-headers~=3.5.0
-openwisp-utils[qa]~=0.7.0
+openwisp-utils[qa]
 redis~=3.5.3
 channels_redis~=3.1.0
 pytest-asyncio~=0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 django-notifications-hq~=1.6.0
 channels~=2.4.0
-openwisp-users~=0.5.0
-openwisp-utils[rest]~=0.7.0
+# TODO set the next point release of openwisp-users when ready
+openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/master
+openwisp-utils[rest]
 swapper~=1.1.0
 markdown~=3.2.0
 celery~=4.4.0


### PR DESCRIPTION
We need this if we want to allow using the master branch in staging systems without failures.

Without this, when installing this module, the older versions of openwisp-users and openwisp-utils will be installed.