### PR TITLE
[fix] Fixed closing notification toast on slow connections #211

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/notifications.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/notifications.js
@@ -323,18 +323,18 @@ function notificationWidget($) {
 
 function markNotificationRead(elem) {
     let elemId = elem.id.replace('ow-', '');
+    try {
+        document.querySelector(`#${elem.id}.ow-notification-elem`).classList.remove('unread');
+    } catch (error) {
+        // no op
+    }
+    notificationReadStatus.set(elemId, 'read');
     notificationSocket.send(
         JSON.stringify({
             type: 'notification',
             notification_id: elemId
         })
     );
-    try {
-        document.querySelector(`#${elem.id}.ow-notification-elem`).classList.remove('unread');
-    } catch (error) {
-        throw error;
-    }
-    notificationReadStatus.set(elemId, 'read');
 }
 
 function initWebSockets($) {


### PR DESCRIPTION
Notification toast will close and flag notification as read
even if notification widget is still reloading.

Closes #211