### PR TITLE
[fix] Unsubscribe button alignment #219

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/css/object-notifications.css
+++ b/openwisp_notifications/static/openwisp-notifications/css/object-notifications.css
@@ -2,7 +2,6 @@
   display: flex;
 }
 .ow-object-notify {
-  display: flex;
   align-items: center;
 }
 
@@ -46,7 +45,7 @@
 #ow-object-notify .ow-icon {
   display: inline-block;
   width: 15px;
-  height: 15px;
+  height: 14px;
   position: relative;
   bottom: -2px;
   background: #fff;


### PR DESCRIPTION
- Reduced `bell-icon` height, removed redundant flex property from `.ow-object-notify`

Fixes #219

![Screenshot from 2022-01-31 22-42-24](https://user-images.githubusercontent.com/56113566/151842582-94cb4b30-2d84-45ed-a35d-3fb30a4dfc5b.png)

