### PR TITLE
[Fix] Error handling send email notification #179

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -169,22 +169,22 @@ def send_email_notification(sender, instance, created, **kwargs):
     # Get email preference of user for this type of notification.
     target_org = getattr(getattr(instance, 'target', None), 'organization_id', None)
     if instance.type and target_org:
-      
+
         try:
             notification_setting = instance.recipient.notificationsetting_set.get(
                 organization=target_org, type=instance.type
             )
         except NotificationSetting.DoesNotExist:
             return
-      
+
         email_preference = notification_setting.email_notification
-        
+
     else:
         # We can not check email preference if notification type is absent,
         # or if target_org is not present
         # therefore send email anyway.
         email_preference = True
-        
+
     if not (email_preference and instance.recipient.email):
         return
 

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -169,16 +169,13 @@ def send_email_notification(sender, instance, created, **kwargs):
     # Get email preference of user for this type of notification.
     target_org = getattr(getattr(instance, 'target', None), 'organization_id', None)
     if instance.type and target_org:
-
         try:
             notification_setting = instance.recipient.notificationsetting_set.get(
                 organization=target_org, type=instance.type
             )
         except NotificationSetting.DoesNotExist:
             return
-
         email_preference = notification_setting.email_notification
-
     else:
         # We can not check email preference if notification type is absent,
         # or if target_org is not present

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -169,16 +169,22 @@ def send_email_notification(sender, instance, created, **kwargs):
     # Get email preference of user for this type of notification.
     target_org = getattr(getattr(instance, 'target', None), 'organization_id', None)
     if instance.type and target_org:
-        notification_setting = instance.recipient.notificationsetting_set.get(
-            organization=target_org, type=instance.type
-        )
+      
+        try:
+            notification_setting = instance.recipient.notificationsetting_set.get(
+                organization=target_org, type=instance.type
+            )
+        except NotificationSetting.DoesNotExist:
+            return
+      
         email_preference = notification_setting.email_notification
+        
     else:
         # We can not check email preference if notification type is absent,
         # or if target_org is not present
         # therefore send email anyway.
         email_preference = True
-
+        
     if not (email_preference and instance.recipient.email):
         return
 

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -818,6 +818,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         data = dict(
             email_subject='Test Email subject', url='https://localhost:8000/admin'
         )
+        self.admin.notificationsetting_set.all().delete()
         Notification.objects.create(
             actor=self.admin,
             recipient=self.admin,
@@ -828,7 +829,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             data=data,
             type="default",
         )
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 0)
 
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -813,7 +813,6 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         user.delete()
         mocked_task.assert_not_called()
 
-
     def test_email_notif_without_notif_setting(self):
         target_obj = self._get_org_user()
         data = dict(
@@ -827,9 +826,10 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             action_object=target_obj,
             target=target_obj,
             data=data,
-            type="default"
+            type="default",
         )
         self.assertEqual(len(mail.outbox), 1)
+
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):
     def setUp(self):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -21,6 +21,7 @@ from openwisp_notifications.exceptions import NotificationRenderException
 from openwisp_notifications.handlers import (
     notify_handler,
     register_notification_cache_update,
+    send_email_notification
 )
 from openwisp_notifications.signals import notify
 from openwisp_notifications.swapper import load_model, swapper_load_model
@@ -851,3 +852,28 @@ class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(notification.target.username, 'new operator name')
         # Done for populating cache
         self.assertEqual(operator_cache.username, 'new operator name')
+
+class test_email_notification(TestOrganizationMixin, TransactionTestCase):
+    def setUp(self):
+        self.user=self._create_user()
+        self.admin = self._create_admin()
+        self.target_obj = self._get_org_user()
+        self.data = dict(
+            email_subject='Test Email subject', url='https://localhost:8000/admin'
+        )
+
+    def test_email_notif_without_notif_setting(self):
+        
+        notif = Notification.objects.create(
+            actor=self.admin,
+            recipient=self.user,
+            description='Test Notification Description',
+            verb='Test Notification',
+            action_object=self.target_obj,
+            target=self.target_obj,
+            data=self.data,
+            type="default"
+        )
+        n=send_email_notification(sender=self.admin,instance=notif,created=True)
+        print(n)
+        self.assertEqual(n, None)


### PR DESCRIPTION
Added exception handling for the issue #179 and test for the same . So ,If throws exception the function will be returned empty and mail will not be sent.