### PR TITLE
[fix] Project dependent test cases #157

### DIFF
--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -23,6 +23,7 @@ Notification = load_model('Notification')
 NotificationSetting = load_model('NotificationSetting')
 notification_queryset = Notification.objects.order_by('-timestamp')
 Group = swapper_load_model('openwisp_users', 'Group')
+Organization = swapper_load_model('openwisp_users', 'Organization')
 
 
 class MockUser:
@@ -205,7 +206,10 @@ class TestAdmin(TestOrganizationMixin, TestMultitenantAdminMixin, TestCase):
         response = self.client.get(
             reverse('admin:openwisp_users_user_change', args=(self.admin.pk,))
         )
-        self.assertContains(response, 'default</option>')
+        self.assertContains(
+            response,
+            f'<option value="{Organization.objects.first().id}">default</option>',
+        )
 
     def test_notification_setting_inline_admin_has_change_permission(self):
         with self.subTest('Test for superuser'):

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -23,7 +23,6 @@ Notification = load_model('Notification')
 NotificationSetting = load_model('NotificationSetting')
 notification_queryset = Notification.objects.order_by('-timestamp')
 Group = swapper_load_model('openwisp_users', 'Group')
-Organization = swapper_load_model('openwisp_users', 'Organization')
 
 
 class MockUser:
@@ -206,9 +205,10 @@ class TestAdmin(TestOrganizationMixin, TestMultitenantAdminMixin, TestCase):
         response = self.client.get(
             reverse('admin:openwisp_users_user_change', args=(self.admin.pk,))
         )
+        organization = self._get_org(org_name='default')
         self.assertContains(
             response,
-            f'<option value="{Organization.objects.first().id}">default</option>',
+            f'<option value="{organization.id}">{organization.name}</option>',
         )
 
     def test_notification_setting_inline_admin_has_change_permission(self):

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -205,7 +205,7 @@ class TestAdmin(TestOrganizationMixin, TestMultitenantAdminMixin, TestCase):
         response = self.client.get(
             reverse('admin:openwisp_users_user_change', args=(self.admin.pk,))
         )
-        self.assertContains(response, '<option value="default">Default Type</option>')
+        self.assertContains(response, 'default</option>')
 
     def test_notification_setting_inline_admin_has_change_permission(self):
         with self.subTest('Test for superuser'):


### PR DESCRIPTION
Check for the default organization instead of default notification type,
Fixes #157