### PR TITLE
1.0.2 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+Version 1.0.2 [2022-07-01]
+--------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fixed `hardcoded static image URLs
+  <https://github.com/openwisp/openwisp-notifications/issues/243>`_.
+  These create issues when static files are served using an
+  external service (e.g. S3 storage buckets).
+- Fixed `"Organization.DoesNotExist" error on creating
+  a new organization <https://github.com/openwisp/openwisp-notifications/issues/238>`_.
+
 Version 1.0.1 [2022-06-09]
 --------------------------
 

--- a/openwisp_notifications/__init__.py
+++ b/openwisp_notifications/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 1, 'final')
+VERSION = (1, 0, 2, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
## Bugfixes

-   Fixed [hardcoded static image URLs][]. These created issues when
    static files are served using an external service (e.g. S3 storage
    buckets).
-   Fixed ["Organization.DoesNotExist" error on creating a new
    organization][].

  [hardcoded static image URLs]: https://github.com/openwisp/openwisp-notifications/issues/243
  ["Organization.DoesNotExist" error on creating a new organization]: https://github.com/openwisp/openwisp-notifications/issues/238