### PR TITLE
[fix] Fixed TemplateDoesNotExist admin error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,8 @@ Setup (integrate into an existing Django project)
         # add openwisp theme
         # (must be loaded here)
         'openwisp_utils.admin_theme',
+        # admin
+        'admin_auto_filters',
         'django.contrib.admin',
         # channels
         'channels',

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     # add openwisp theme
     # (must be loaded here)
     'openwisp_utils.admin_theme',
+    # admin
+    'admin_auto_filters',
     'django.contrib.admin',
     # rest framework
     'rest_framework',


### PR DESCRIPTION
We have recently added admin autocomplete filters to various OpenWISP modules, including `openwisp-users`. Therefore, we need to add **'admin_auto_filters'** to **INSTALLED_APPS** so that Django can locate the correct filter template location.

#### Before
 
![Screenshot from 2023-03-27 15-17-54](https://user-images.githubusercontent.com/56113566/227906698-27ac7333-6006-415a-b216-814dcdb53b35.png)

#### After

![Screenshot from 2023-03-27 15-17-58](https://user-images.githubusercontent.com/56113566/227906712-b430f130-116c-4618-b940-ad3c4b8f0e16.png) 