### PR TITLE
[fix] Fixed `parse_header` error

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ channels_redis~=3.4.0
 pytest-asyncio~=0.14.0
 pytest-django~=4.1.0
 freezegun~=1.1.0
+djangorestframework~=3.14.0


### PR DESCRIPTION
Recently, Django released its 4.2 version and remove the `django.http.multipartparser.parse_header()` function, So `djangorestframework` required version also get changed. So, added the new version of `djangorestframework` to use `django.utils.http.parse_header_parameters()` instead of `django.http.multipartparser.parse_header()`. As it is required by the notification widget. 

**Before**
![image](https://user-images.githubusercontent.com/112396029/230773275-e2be9ddc-56c8-4738-a0f2-102946421aaa.png)

**After**
![image](https://user-images.githubusercontent.com/112396029/230773420-24569dc1-f8ac-4a18-a602-f76527f24524.png)