### PR TITLE
[fix] Assigned a callable to model choices attribute to deal with the latest NOTIFICATION_CHOICES

### DIFF
--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -20,7 +20,7 @@ from swapper import get_model_name
 from openwisp_notifications import settings as app_settings
 from openwisp_notifications.exceptions import NotificationRenderException
 from openwisp_notifications.types import (
-    NOTIFICATION_CHOICES,
+    get_notification_choices,
     get_notification_configuration,
 )
 from openwisp_notifications.utils import _get_absolute_url, _get_object_link
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class AbstractNotification(UUIDModel, BaseNotification):
     CACHE_KEY_PREFIX = 'ow-notifications-'
-    type = models.CharField(max_length=30, null=True, choices=NOTIFICATION_CHOICES)
+    type = models.CharField(max_length=30, null=True, choices=get_notification_choices)
     _actor = BaseNotification.actor
     _action_object = BaseNotification.action_object
     _target = BaseNotification.target
@@ -212,7 +212,7 @@ class AbstractNotificationSetting(UUIDModel):
     type = models.CharField(
         max_length=30,
         null=True,
-        choices=NOTIFICATION_CHOICES,
+        choices=get_notification_choices,
         verbose_name='Notification Type',
     )
     organization = models.ForeignKey(

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -65,7 +65,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
 
         self._get_admin()
         self.assertEqual(queryset.count(), 1)
-        self.assertEquals(
+        self.assertEqual(
             queryset.first().__str__(), 'Test Notification Type - default'
         )
 

--- a/openwisp_notifications/types.py
+++ b/openwisp_notifications/types.py
@@ -23,6 +23,15 @@ NOTIFICATION_CHOICES = [('default', 'Default Type')]
 NOTIFICATION_ASSOCIATED_MODELS = set()
 
 
+def get_notification_choices():
+    """
+    Return a list of notification choices.
+    This method used as a callable for 'choices' attribute in models
+    allowing the models to deal with the updated list.
+    """
+    return NOTIFICATION_CHOICES
+
+
 def get_notification_configuration(notification_type):
     if not notification_type:
         return {}


### PR DESCRIPTION
After running the tests locally I encountered some errors. One caused by a typo [here](https://github.com/openwisp/openwisp-notifications/blob/master/openwisp_notifications/tests/test_notification_setting.py#L68). Additionally, certain test cases are updating the NOTIFICATION_CHOICES, but these updates are not reflected in the choices attribute of the affected models.


![full_clean_error](https://github.com/openwisp/openwisp-notifications/assets/92472200/c80a4fe6-2d05-43ce-bc57-f8b882374146)
