### PR TITLE
[tests] Fixed tests that polluted the test environment

### DIFF
--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -7,8 +7,8 @@ from django.db.models import Q
 from django.db.utils import OperationalError
 from django.utils import timezone
 
+from openwisp_notifications import types
 from openwisp_notifications.swapper import load_model, swapper_load_model
-from openwisp_notifications.types import NOTIFICATION_TYPES
 from openwisp_utils.tasks import OpenwispCeleryTask
 
 User = get_user_model()
@@ -105,7 +105,7 @@ def update_superuser_notification_settings(instance_id, is_superuser, is_created
     create_notification_settings(
         user=user,
         organizations=Organization.objects.all(),
-        notification_types=NOTIFICATION_TYPES.keys(),
+        notification_types=types.NOTIFICATION_TYPES.keys(),
     )
 
 
@@ -119,7 +119,7 @@ def ns_register_unregister_notification_type(
     """
 
     notification_types = (
-        [notification_type] if notification_type else NOTIFICATION_TYPES.keys()
+        [notification_type] if notification_type else types.NOTIFICATION_TYPES.keys()
     )
 
     organizations = Organization.objects.all()
@@ -166,7 +166,7 @@ def update_org_user_notificationsetting(org_user_id, user_id, org_id, is_org_adm
     create_notification_settings(
         user=user,
         organizations=[organization],
-        notification_types=NOTIFICATION_TYPES.keys(),
+        notification_types=types.NOTIFICATION_TYPES.keys(),
     )
 
 
@@ -192,7 +192,7 @@ def ns_organization_created(instance_id):
         create_notification_settings(
             user=user,
             organizations=[organization],
-            notification_types=NOTIFICATION_TYPES.keys(),
+            notification_types=types.NOTIFICATION_TYPES.keys(),
         )
 
 

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -13,8 +13,8 @@ from openwisp_notifications.signals import notify
 from openwisp_notifications.swapper import load_model, swapper_load_model
 from openwisp_notifications.tests.test_helpers import (
     TEST_DATETIME,
+    mock_notification_types,
     register_notification_type,
-    unregister_notification_type,
 )
 from openwisp_users.tests.test_api import AuthenticationMixin
 from openwisp_users.tests.utils import TestOrganizationMixin
@@ -436,6 +436,7 @@ class TestNotificationApi(
             self.assertEqual(response.data['count'], number_of_notifications)
 
     @capture_any_output()
+    @mock_notification_types
     def test_malformed_notifications(self):
         test_type = {
             'verbose_name': 'Test Notification Type',
@@ -469,9 +470,8 @@ class TestNotificationApi(
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
 
-        unregister_notification_type('test_type')
-
     @capture_any_output()
+    @mock_notification_types
     @patch('openwisp_notifications.tasks.delete_obsolete_objects.delay')
     def test_obsolete_notifications_busy_worker(self, mocked_task):
         """
@@ -515,8 +515,6 @@ class TestNotificationApi(
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
             self.assertDictEqual(response.data, {'detail': NOT_FOUND_ERROR})
-
-        unregister_notification_type('test_type')
 
     def test_notification_setting_list_api(self):
         self._create_org_user(is_admin=True)
@@ -904,6 +902,7 @@ class TestNotificationApi(
             self.assertIn('object_content_type', ignore_obj_notification)
             self.assertIsNone(ignore_obj_notification['valid_till'])
 
+    @capture_any_output()
     @patch('openwisp_notifications.tasks.delete_notification.delay')
     def test_deleted_notification_type(self, *args):
         notify.send(sender=self.admin, type='default', target=self.admin)

--- a/openwisp_notifications/tests/test_utils.py
+++ b/openwisp_notifications/tests/test_utils.py
@@ -54,17 +54,21 @@ class TestChecks(TestCase, TestOrganizationMixin):
     )
     def test_cors_not_configured(self):
         # If INSTALLED_APPS not configured
-        with patch('openwisp_notifications.types.NOTIFICATION_TYPES', dict(),), patch(
-            'openwisp_utils.admin_theme.menu.MENU', {}
-        ), self.modify_settings(
+        with patch.multiple(
+            'openwisp_notifications.types',
+            NOTIFICATION_TYPES={},
+            NOTIFICATION_CHOICES=[],
+        ), patch('openwisp_utils.admin_theme.menu.MENU', {}), self.modify_settings(
             INSTALLED_APPS={'remove': 'corsheaders'}
         ), StringIO() as stderr:
             management.call_command('check', stderr=stderr)
             self.assertIn('django-cors-headers', stderr.getvalue())
 
         # If MIDDLEWARE not configured
-        with patch(
-            'openwisp_notifications.types.NOTIFICATION_TYPES', dict()
+        with patch.multiple(
+            'openwisp_notifications.types',
+            NOTIFICATION_TYPES={},
+            NOTIFICATION_CHOICES=[],
         ), self.modify_settings(
             MIDDLEWARE={'remove': 'corsheaders.middleware.CorsMiddleware'}
         ), StringIO() as stderr:

--- a/tests/openwisp2/sample_notifications/apps.py
+++ b/tests/openwisp2/sample_notifications/apps.py
@@ -15,7 +15,7 @@ class SampleNotificationsConfig(OpenwispNotificationsConfig):
     def ready(self):
         super().ready()
         self.register_notification_types()
-        self.connect_recievers()
+        self.connect_receivers()
 
     def register_notification_types(self):
         register_notification_type(
@@ -29,7 +29,7 @@ class SampleNotificationsConfig(OpenwispNotificationsConfig):
             },
         )
 
-    def connect_recievers(self):
+    def connect_receivers(self):
         from openwisp_notifications.handlers import register_notification_cache_update
 
         Organization = load_model('openwisp_users', 'Organization')


### PR DESCRIPTION
Mock NOTIFICATION_TYPE and NOTIFICATION_CHOICES to avoid polluting the test environment from notification types registered in the test.