### PR TITLE
[fix] Prevent sending multiple identical notifications #277

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -114,7 +114,9 @@ def notify_handler(**kwargs):
         # Check if recipient is User, Group or QuerySet
         if isinstance(recipient, Group):
             recipients = recipient.user_set.filter(where_group)
-        elif isinstance(recipient, (QuerySet, list)):
+        elif isinstance(recipient, QuerySet):
+            recipients = recipient.distinct()
+        elif isinstance(recipient, list):
             recipients = recipient
         else:
             recipients = [recipient]
@@ -126,6 +128,7 @@ def notify_handler(**kwargs):
             .order_by('date_joined')
             .filter(where)
             .exclude(not_where)
+            .distinct()
         )
     optional_objs = [
         (kwargs.pop(opt, None), opt) for opt in ('target', 'action_object')

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -893,6 +893,23 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         # we don't send emails to unverified email addresses
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_that_the_notification_is_only_sent_once_to_the_user(self):
+        first_org = self._create_org()
+        first_org.organization_id = first_org.id
+        second_org = self._create_org(name='second-org')
+        second_org.organization_id = second_org.id
+        OrganizationUser.objects.create(user=self.admin, organization=first_org)
+        OrganizationUser.objects.create(user=self.admin, organization=second_org)
+        self.notification_options.update(
+            {
+                'type': 'default',
+                'sender': first_org,
+                'target': first_org,
+            }
+        )
+        self._create_notification()
+        self.assertEqual(notification_queryset.count(), 1)
+
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):
     def setUp(self):


### PR DESCRIPTION
If a user is in several organizations,
they will receive multiple identical notifications. The reason for this is that the database query,
which determines which user should receive the notification, does a LEFT OUTER JOIN with the "openwisp_users_organizationuser" table. In this table, a user is multiple times listed,
when he is in several organizations.
Therefore the query returns such a user multiple times, which will then receive multiple identical notifications. This commit fixes this bug by adding a distinct to all user queries.

Fixes #277