### PR TITLE
[fix] Fixed unnecessary triggering of celery tasks #283

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -300,13 +300,45 @@ def notification_setting_delete_org_user(instance, **kwargs):
     )
 
 
-@receiver(post_save, sender=User, dispatch_uid='user_notification_setting')
-def update_superuser_notification_settings(instance, created, **kwargs):
-    transaction.on_commit(
-        lambda: tasks.update_superuser_notification_settings.delay(
-            instance.pk, instance.is_superuser, created
+@receiver(pre_save, sender=User, dispatch_uid='superuser_demoted_notification_setting')
+def update_superuser_notification_settings(instance, update_fields, **kwargs):
+    """
+    If user is demoted from superuser status, then
+    remove notification settings for non-managed organizations.
+
+    If user is promoted to superuser, then
+    create notification settings for all organizations.
+    """
+    if update_fields is not None and 'is_superuser' not in update_fields:
+        # No-op if is_superuser field is not being updated.
+        # If update_fields is None, it means any field could be updated.
+        return
+    try:
+        db_instance = User.objects.only('is_superuser').get(pk=instance.pk)
+    except User.DoesNotExist:
+        # User is being created
+        return
+    # If user is demoted from superuser to non-superuser
+    if db_instance.is_superuser and not instance.is_superuser:
+        transaction.on_commit(
+            lambda: tasks.update_superuser_notification_settings.delay(
+                instance.pk, is_superuser=False
+            )
         )
-    )
+    elif not db_instance.is_superuser and instance.is_superuser:
+        transaction.on_commit(
+            lambda: tasks.update_superuser_notification_settings.delay(
+                instance.pk, is_superuser=True
+            )
+        )
+
+
+@receiver(post_save, sender=User, dispatch_uid='create_superuser_notification_settings')
+def create_superuser_notification_settings(instance, created, **kwargs):
+    if created and instance.is_superuser:
+        transaction.on_commit(
+            lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
+        )
 
 
 @receiver(

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -83,30 +83,41 @@ def create_notification_settings(user, organizations, notification_types):
 
 
 @shared_task(base=OpenwispCeleryTask)
-def update_superuser_notification_settings(instance_id, is_superuser, is_created):
+def update_superuser_notification_settings(instance_id, is_superuser, is_created=False):
+    """
+    NOTE: This task is deprecated and only kept for backward compatibility.
+    It will be removed in 1.2.0 release.
+    """
+    if not is_superuser:
+        superuser_demoted_notification_setting(instance_id)
+    else:
+        create_superuser_notification_settings(instance_id)
+
+
+@shared_task(base=OpenwispCeleryTask)
+def create_superuser_notification_settings(user_id):
     """
     Adds notification setting for all notification types and organizations.
-    If a superuser gets demoted, flags it's notification settings as deleted.
     """
-    user = User.objects.get(pk=instance_id)
-
-    # When a user is demoted from superuser status,
-    # only keep notification settings for organization they are member of.
-    if not (is_superuser or is_created):
-        NotificationSetting.objects.filter(user_id=instance_id).exclude(
-            organization__in=user.organizations_managed
-        ).update(deleted=True)
-        return
-
-    if not is_superuser:
-        return
-
+    user = User.objects.get(pk=user_id)
     # Create notification settings for superuser
     create_notification_settings(
         user=user,
         organizations=Organization.objects.all(),
         notification_types=types.NOTIFICATION_TYPES.keys(),
     )
+
+
+@shared_task(base=OpenwispCeleryTask)
+def superuser_demoted_notification_setting(user_id):
+    """
+    Flags NotificationSettings as deleted for non-managed organizations
+    when a superuser is demoted to a non-superuser.
+    """
+    user = User.objects.get(pk=user_id)
+    NotificationSetting.objects.filter(user_id=user_id).exclude(
+        organization__in=user.organizations_managed
+    ).update(deleted=True)
 
 
 @shared_task(base=OpenwispCeleryTask)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Fixes #283

## Description of Changes

Fixed unnecessary triggering of the `update_superuser_notification_settings task`.