### PR TITLE
[fix] Notification preferences API returns fallback value if None #351

### DIFF
--- a/openwisp_notifications/api/serializers.py
+++ b/openwisp_notifications/api/serializers.py
@@ -83,6 +83,12 @@ class NotificationSettingSerializer(serializers.ModelSerializer):
         exclude = ['user']
         read_only_fields = ['organization', 'type']
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['web'] = instance.web_notification
+        data['email'] = instance.email_notification
+        return data
+
 
 class IgnoreObjectNotificationSerializer(serializers.ModelSerializer):
     class Meta:

--- a/openwisp_notifications/api/serializers.py
+++ b/openwisp_notifications/api/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import NotFound
 
 from openwisp_notifications.exceptions import NotificationRenderException
 from openwisp_notifications.swapper import load_model
+from openwisp_utils.api.serializers import ValidatedModelSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ class NotificationListSerializer(NotificationSerializer):
         list_serializer_class = CustomListSerializer
 
 
-class NotificationSettingSerializer(serializers.ModelSerializer):
+class NotificationSettingSerializer(ValidatedModelSerializer):
     organization_name = serializers.CharField(
         source='organization.name', read_only=True
     )

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -646,13 +646,14 @@ class TestNotificationApi(
                 'notification_setting',
                 notification_setting.pk,
             )
-            response = self.client.get(url)
+            with self.assertNumQueries(3):
+                response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             data = response.data
             self.assertEqual(data['id'], str(notification_setting.id))
             self.assertEqual(data['organization'], notification_setting.organization.pk)
-            self.assertEqual(data['web'], notification_setting.web)
-            self.assertEqual(data['email'], notification_setting.email)
+            self.assertEqual(data['web'], notification_setting.web_notification)
+            self.assertEqual(data['email'], notification_setting.email_notification)
 
         with self.subTest(
             'Test retrieving details for existing notification setting as admin'


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #351



## Description of Changes

The notification prefences API would return
`NotificationSetting.web_notification` for the `web` field and `NotificationSetting.email_notification` for the `email` field.

These methods returns the fallback value from the notification type configuration, when the database contains `None`.

