### PR TITLE
[feature] Suppress email verification prompt when email notifications a…

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -400,6 +400,14 @@ def check_email_verification(sender, user, request, **kwargs):
     # abort if this is not an admin login
     if not user.is_staff or not request.path.startswith(admin_path):
         return
+
+    email_notifs_enabled = NotificationSetting.objects.filter(
+        user=user, email=True
+    ).exists()
+    if not email_notifs_enabled:
+        # if no email notifications enabled, don't prompt
+        return
+
     has_verified_email = EmailAddress.objects.filter(user=user, verified=True).exists()
     # abort if user already has a verified email
     # or doesn't have an email at all


### PR DESCRIPTION
…re disabled #343

Updated the check_email_verification function to check the email boolean value before sending email verification notification. Tested by creating 2 separate users with opposite boolean values and if email=True (email notification enabled) then only user is prompted with notification, else restrained.

Fixes #343

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #343.


## Description of Changes

As mentioned in the issue, the check_email_verification function was updated to ensure that only is email boolean value is true (email notifications are enabled) then only user gets prompted for verification.
