### PR TITLE
[chores] Avoid email notification warning if email notifications are disabled

### DIFF
--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -403,6 +403,11 @@ class AbstractNotificationSetting(UUIDModel):
             return self.web
         return self.type_config.get('web_notification')
 
+    @classmethod
+    def email_notifications_enabled(cls, user):
+        """Returns ``True`` if ``user`` has at least one email notification setting enabled."""
+        return cls.objects.filter(user=user, email=True).exists()
+
 
 class AbstractIgnoreObjectNotification(UUIDModel):
     """

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -394,11 +394,19 @@ def update_notification_cache(sender, instance, **kwargs):
     transaction.on_commit(invalidate_cache)
 
 
+class NotificationUtils:
+    @classmethod
+    def email_notifications_enabled(cls, user):
+        return NotificationSetting.objects.filter(user=user, email=True).exists()
+
+
 @receiver(user_logged_in)
 def check_email_verification(sender, user, request, **kwargs):
     admin_path = reverse('admin:index')
     # abort if this is not an admin login
     if not user.is_staff or not request.path.startswith(admin_path):
+        return
+    if not NotificationUtils.email_notifications_enabled(user):
         return
     has_verified_email = EmailAddress.objects.filter(user=user, verified=True).exists()
     # abort if user already has a verified email

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -394,19 +394,13 @@ def update_notification_cache(sender, instance, **kwargs):
     transaction.on_commit(invalidate_cache)
 
 
-class NotificationUtils:
-    @classmethod
-    def email_notifications_enabled(cls, user):
-        return NotificationSetting.objects.filter(user=user, email=True).exists()
-
-
 @receiver(user_logged_in)
 def check_email_verification(sender, user, request, **kwargs):
     admin_path = reverse('admin:index')
     # abort if this is not an admin login
     if not user.is_staff or not request.path.startswith(admin_path):
         return
-    if not NotificationUtils.email_notifications_enabled(user):
+    if not NotificationSetting.email_notifications_enabled(user):
         return
     has_verified_email = EmailAddress.objects.filter(user=user, verified=True).exists()
     # abort if user already has a verified email

--- a/openwisp_notifications/tests/test_views.py
+++ b/openwisp_notifications/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
-from openwisp_notifications.swapper import load_model, swapper_load_model
+from openwisp_notifications.swapper import load_model
 
 User = get_user_model()
 
@@ -118,13 +118,14 @@ class TestCheckEmailVerification(TestCase):
             primary=True,
             verified=False,
         )
-
-    def test_warning_on_admin_login(self):
         NotificationSetting.objects.update_or_create(
             user=self.user,
             type='default',
             defaults={'email': True, 'web': True},
         )
+
+    def test_warning_on_admin_login(self):
+        self.assertTrue(NotificationSetting.email_notifications_enabled(self.user))
         login_url = reverse('admin:login')
         response = self.client.post(
             login_url,
@@ -146,10 +147,11 @@ class TestCheckEmailVerification(TestCase):
         expected_url = reverse('notifications:resend_verification_email')
         self.assertIn(expected_url, message)
 
-    def test_warning_disabled(self):
+    def test_email_notifications_disabled_no_warning(self):
         NotificationSetting.objects.update_or_create(
             user=self.user, type='default', defaults={'email': False, 'web': True}
         )
+        self.assertFalse(NotificationSetting.email_notifications_enabled(self.user))
         login_url = reverse('admin:login')
         response = self.client.post(
             login_url,

--- a/openwisp_notifications/tests/test_views.py
+++ b/openwisp_notifications/tests/test_views.py
@@ -8,7 +8,11 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
+from openwisp_notifications.swapper import load_model, swapper_load_model
+
 User = get_user_model()
+
+NotificationSetting = load_model('NotificationSetting')
 
 
 class TestResendVerificationEmailView(TestCase):
@@ -116,6 +120,11 @@ class TestCheckEmailVerification(TestCase):
         )
 
     def test_warning_on_admin_login(self):
+        NotificationSetting.objects.update_or_create(
+            user=self.user,
+            type='default',
+            defaults={'email': True, 'web': True},
+        )
         login_url = reverse('admin:login')
         response = self.client.post(
             login_url,
@@ -136,3 +145,20 @@ class TestCheckEmailVerification(TestCase):
         self.assertIn('verify your email address', message)
         expected_url = reverse('notifications:resend_verification_email')
         self.assertIn(expected_url, message)
+
+    def test_warning_disabled(self):
+        NotificationSetting.objects.update_or_create(
+            user=self.user, type='default', defaults={'email': False, 'web': True}
+        )
+        login_url = reverse('admin:login')
+        response = self.client.post(
+            login_url,
+            {
+                'username': 'adminuser',
+                'password': 'adminpass123',
+                'next': reverse('admin:index'),
+            },
+            follow=True,
+        )
+        messages_list = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages_list), 0)

--- a/openwisp_notifications/tests/test_views.py
+++ b/openwisp_notifications/tests/test_views.py
@@ -125,7 +125,6 @@ class TestCheckEmailVerification(TestCase):
         )
 
     def test_warning_on_admin_login(self):
-        self.assertTrue(NotificationSetting.email_notifications_enabled(self.user))
         login_url = reverse('admin:login')
         response = self.client.post(
             login_url,


### PR DESCRIPTION
… are disabled #343

Updated the check_email_verification function to check the email boolean value before sending email verification notification. Tested by creating 2 separate users with opposite boolean values and if email=True (email notification enabled) then only user is prompted with notification, else restrained.

Fixes #343

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #343.

## Description of Changes

As mentioned in the issue, the check_email_verification function was updated to ensure that only is email boolean value is true (email notifications are enabled) then only user gets prompted for verification. Updated towards class method for better readability. Tests were written as mentioned and manual checking was done by simulating 2 users with different email boolean values.
