### PR TITLE
[notifications] Make notification verb dynamic instead of stored #334

### DIFF
--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -273,6 +273,16 @@ class AbstractNotification(UUIDModel, BaseNotification):
             reverse('notifications:notification_read_redirect', args=(self.pk,))
         )
 
+    @property
+    def verb(self):
+        stored_verb = self.__dict__.get('verb')
+        if stored_verb:
+            return stored_verb
+        if self.type:
+            config = get_notification_configuration(self.type)
+            return config.get('verb', 'undefined')
+        return 'undefined'
+
 
 class AbstractNotificationSetting(UUIDModel):
     _RECEIVE_HELP = (

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -66,7 +66,7 @@ def notify_handler(**kwargs):
     level = kwargs.pop(
         'level', notification_template.get('level', Notification.LEVELS.info)
     )
-    verb = notification_template.get('verb', kwargs.pop('verb', None))
+    # verb = notification_template.get('verb', kwargs.pop('verb', None))
     user_app_name = User._meta.app_label
 
     where = Q(is_superuser=True)
@@ -145,7 +145,7 @@ def notify_handler(**kwargs):
         notification = Notification(
             recipient=recipient,
             actor=actor,
-            verb=str(verb),
+            # verb=str(verb),
             public=public,
             description=description,
             timestamp=timestamp,


### PR DESCRIPTION
The notification verb was previously saved in the database, preventing existing notifications from reflecting verb updates. Now the verb is calculated dynamically via a property, ensuring messages always show the current verb.

Fixes #334

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #334.

## Description of Changes

This change removes storing notification verbs in the database and introduces a dynamic property-based approach instead. The verb is now retrieved from notification configuration at runtime based on notification type. This ensures all notifications always display their current verb definition regardless of when they were created. Tested manually by updating verb on admin dashboard to check verb updates.
