### PR TITLE
[fix] Send credentials in async requests (preferences.js)

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/preferences.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/preferences.js
@@ -23,6 +23,10 @@ function getAbsoluteUrl(url) {
       $.ajax({
         url: url,
         dataType: "json",
+        xhrFields: {
+          withCredentials: true,
+        },
+        crossDomain: true,
         beforeSend: function () {
           $(".loader").show();
           $(".global-settings").hide();
@@ -364,6 +368,10 @@ function getAbsoluteUrl(url) {
           "X-CSRFToken": $('input[name="csrfmiddlewaretoken"]').val(),
         },
         contentType: "application/json",
+        xhrFields: {
+          withCredentials: true,
+        },
+        crossDomain: true,
         data: JSON.stringify({ web: isWebChecked, email: isEmailChecked }),
         success: function () {
           showToast("success", gettext("Settings updated successfully."));
@@ -481,6 +489,10 @@ function getAbsoluteUrl(url) {
           "X-CSRFToken": $('input[name="csrfmiddlewaretoken"]').val(),
         },
         contentType: "application/json",
+        xhrFields: {
+          withCredentials: true,
+        },
+        crossDomain: true,
         data: JSON.stringify(data),
         success: function () {
           showToast(
@@ -765,6 +777,10 @@ function getAbsoluteUrl(url) {
             "X-CSRFToken": $('input[name="csrfmiddlewaretoken"]').val(),
           },
           contentType: "application/json",
+          xhrFields: {
+            withCredentials: true,
+          },
+          crossDomain: true,
           data: data,
           success: function () {
             showToast(


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

AJAX requests should include credentials when API is hosted on a separate host (docker-openwisp).

