### PR TITLE
[fix] Hide notification preferences for disabled orgs #366

### DIFF
--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -123,9 +123,9 @@ class BaseNotificationSettingView(GenericAPIView):
         if getattr(self, "swagger_fake_view", False):
             return NotificationSetting.objects.none()  # pragma: no cover
         user_id = self.kwargs.get("user_id", self.request.user.id)
-        return NotificationSetting.objects.filter(user_id=user_id).filter(
-            Q(organization__isnull=True) | Q(organization__is_active=True)
-        )
+        return NotificationSetting.objects.exclude(
+            organization__is_active=False
+        ).filter(user_id=user_id)
 
 
 class NotificationSettingListView(BaseNotificationSettingView, ListModelMixin):

--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -1,5 +1,4 @@
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django_filters.rest_framework import DjangoFilterBackend

--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django_filters.rest_framework import DjangoFilterBackend
@@ -122,7 +123,9 @@ class BaseNotificationSettingView(GenericAPIView):
         if getattr(self, "swagger_fake_view", False):
             return NotificationSetting.objects.none()  # pragma: no cover
         user_id = self.kwargs.get("user_id", self.request.user.id)
-        return NotificationSetting.objects.filter(user_id=user_id)
+        return NotificationSetting.objects.filter(user_id=user_id).filter(
+            Q(organization__isnull=True) | Q(organization__is_active=True)
+        )
 
 
 class NotificationSettingListView(BaseNotificationSettingView, ListModelMixin):

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1140,11 +1140,17 @@ class TestNotificationApi(
         inactive_org = Organization(name="inactive", slug="inactive", is_active=False)
         inactive_org.full_clean()
         inactive_org.save()
-        NotificationSetting(user=user, organization=None).full_clean(); NotificationSetting(user=user, organization=None).save()
-        NotificationSetting(user=user, organization=active_org).full_clean(); NotificationSetting(user=user, organization=active_org).save()
-        NotificationSetting(user=user, organization=inactive_org).full_clean(); NotificationSetting(user=user, organization=inactive_org).save()
+        NotificationSetting(user=user, organization=None).full_clean()
+        NotificationSetting(user=user, organization=None).save()
+        NotificationSetting(user=user, organization=active_org).full_clean()
+        NotificationSetting(user=user, organization=active_org).save()
+        NotificationSetting(user=user, organization=inactive_org).full_clean()
+        NotificationSetting(user=user, organization=inactive_org).save()
         self.client.force_login(user)
-        url = reverse("notifications:user_notification_setting_list", kwargs={"user_id": str(user.id)})
+        url = reverse(
+            "notifications:user_notification_setting_list",
+            kwargs={"user_id": str(user.id)},
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         org_ids = [item["organization"] for item in response.data["results"]]

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1138,12 +1138,8 @@ class TestNotificationApi(
         user = self._create_user()
         active_org = self._get_org("active")
         inactive_org = self._create_org(name="inactive", slug="inactive", is_active=False)
-        NotificationSetting(user=user, organization=None).full_clean()
-        NotificationSetting(user=user, organization=None).save()
-        NotificationSetting(user=user, organization=active_org).full_clean()
-        NotificationSetting(user=user, organization=active_org).save()
-        NotificationSetting(user=user, organization=inactive_org).full_clean()
-        NotificationSetting(user=user, organization=inactive_org).save()
+        self._create_org_user(user=user, org=active)
+        self._create_org_user(user=user, org=inactive)
         self.client.force_login(user)
         url = reverse(
             "notifications:user_notification_setting_list",

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1137,9 +1137,7 @@ class TestNotificationApi(
     def test_preferences_api_excludes_disabled_organizations(self):
         user = self._create_user()
         active_org = self._get_org("active")
-        inactive_org = Organization(name="inactive", slug="inactive", is_active=False)
-        inactive_org.full_clean()
-        inactive_org.save()
+        inactive_org = self._create_org(name="inactive", slug="inactive", is_active=False)
         NotificationSetting(user=user, organization=None).full_clean()
         NotificationSetting(user=user, organization=None).save()
         NotificationSetting(user=user, organization=active_org).full_clean()

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1147,8 +1147,6 @@ class TestNotificationApi(
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        org_ids = [item["organization"] for item in response.data["results"]]
-        self.assertEqual(len(org_ids), 2)
-        self.assertIn(None, org_ids)
-        self.assertIn(str(active_org.id), [str(i) for i in org_ids])
-        self.assertNotIn(str(inactive_org.id), org_ids)
+        # ensure preferences from disabled orgs are not shown
+        for obj in response.data["results"]: 
+            self.assertNotEqual(obj["organization_id"], str(inactive.id))

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1137,9 +1137,11 @@ class TestNotificationApi(
     def test_preferences_api_excludes_disabled_organizations(self):
         user = self._create_user()
         active_org = self._get_org("active")
-        inactive_org = self._create_org(name="inactive", slug="inactive", is_active=False)
-        self._create_org_user(user=user, org=active)
-        self._create_org_user(user=user, org=inactive)
+        inactive_org = self._create_org(
+            name="inactive", slug="inactive", is_active=False
+        )
+        self._create_org_user(user=user, organization=active_org)
+        self._create_org_user(user=user, organization=inactive_org)
         self.client.force_login(user)
         url = reverse(
             "notifications:user_notification_setting_list",
@@ -1148,5 +1150,5 @@ class TestNotificationApi(
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # ensure preferences from disabled orgs are not shown
-        for obj in response.data["results"]: 
-            self.assertNotEqual(obj["organization_id"], str(inactive.id))
+        for obj in response.data["results"]:
+            self.assertNotEqual(obj["organization_id"], str(inactive_org.id))

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
-from django.db.models import Q
 from django.db.models.signals import post_save
 from django.test import TransactionTestCase
+from django.urls import reverse
 
 from openwisp_notifications.handlers import (
     notification_type_registered_unregistered_handler,
@@ -398,17 +398,35 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
                 global_setting.full_clean()
                 global_setting.save()
 
-    def test_notification_setting_inactive_organizations(self):
-        user = self._get_user()
-        active_org = Organization.objects.create(name="active-org", is_active=True)
-        inactive_org = Organization.objects.create(name="inactive-org", is_active=False)
-        NotificationSetting.objects.create(user=user, organization=None)
-        NotificationSetting.objects.create(user=user, organization=active_org)
-        NotificationSetting.objects.create(user=user, organization=inactive_org)
-        qs = NotificationSetting.objects.filter(user=user).filter(
-            Q(organization__isnull=True) | Q(organization__is_active=True)
+    @mock_notification_types
+    def test_preferences_api_excludes_disabled_organizations(self):
+        def create_validated_instance(Model, **data):
+            obj = Model(**data)
+            obj.full_clean()
+            obj.save()
+            return obj
+
+        user = self._create_user()
+        active_org = self._get_org("active")
+        inactive_org = create_validated_instance(
+            Organization, name="inactive", slug="inactive", is_active=False
         )
-        self.assertEqual(qs.count(), 2)
-        for setting in qs:
-            if setting.organization is not None:
-                self.assertTrue(setting.organization.is_active)
+        create_validated_instance(NotificationSetting, user=user, organization=None)
+        create_validated_instance(
+            NotificationSetting, user=user, organization=active_org
+        )
+        create_validated_instance(
+            NotificationSetting, user=user, organization=inactive_org
+        )
+        self.client.force_login(user)  # to prevent auth error in test
+        url = reverse(
+            "notifications:user_notification_setting_list",
+            kwargs={"user_id": str(user.id)},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        org_ids = [item["organization"] for item in response.data["results"]]
+        self.assertEqual(len(org_ids), 2)
+        self.assertIn(None, org_ids)
+        self.assertIn(str(active_org.id), [str(i) for i in org_ids])
+        self.assertNotIn(str(inactive_org.id), org_ids)


### PR DESCRIPTION
Filtered out notification settings linked to disabled organizations by modifying the queryset. Added a test to ensure preferences from inactive organizations are excluded from user settings.

Fixes #366

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #366

## Description of Changes

Updated the queryset to exclude notification settings from inactive organizations. Implemented a test to verify that user preferences tied to disabled organizations are not returned.
