### PR TITLE
[fix:tests] Allow overriding users app_label in tests

### DIFF
--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -78,6 +78,7 @@ class TestAdmin(BaseTestAdmin):
     """
 
     app_label = "openwisp_notifications"
+    users_app_label = "openwisp_users"
 
     def test_zero_notifications(self):
         r = self.client.get(self._url)
@@ -157,13 +158,15 @@ class TestAdmin(BaseTestAdmin):
             self.assertContains(response, "wss")
 
     def test_ignore_notification_widget_add_view(self):
-        url = reverse("admin:openwisp_users_organization_add")
+        url = reverse(f"admin:{self.users_app_label}_organization_add")
         response = self.client.get(url)
         self.assertNotContains(response, "owIsChangeForm")
 
     def test_notification_preferences_button_staff_user(self):
         user = self._create_user(is_staff=True)
-        user_admin_page = reverse("admin:openwisp_users_user_change", args=(user.pk,))
+        user_admin_page = reverse(
+            f"admin:{self.users_app_label}_user_change", args=(user.pk,)
+        )
         expected_url = reverse(
             "notifications:user_notification_preference", args=(user.pk,)
         )
@@ -192,6 +195,8 @@ class TestAdminMedia(BaseTestAdmin):
     Tests notifications admin media
     """
 
+    users_app_label = "openwisp_users"
+
     def test_jquery_import(self):
         response = self.client.get(self._url)
         self.assertInHTML(
@@ -219,7 +224,7 @@ class TestAdminMedia(BaseTestAdmin):
 
     def test_object_notification_setting_empty(self):
         response = self.client.get(
-            reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+            reverse(f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,))
         )
         self.assertNotContains(
             response, 'src="/static/openwisp-notifications/js/object-notifications.js"'
@@ -231,7 +236,7 @@ class TestAdminMedia(BaseTestAdmin):
     def test_object_notification_setting_configured(self):
         _add_object_notification_widget()
         response = self.client.get(
-            reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+            reverse(f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,))
         )
         self.assertContains(
             response,
@@ -243,7 +248,9 @@ class TestAdminMedia(BaseTestAdmin):
         with self.assertWarns(MediaOrderConflictWarning):
             _add_object_notification_widget()
             response = self.client.get(
-                reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+                reverse(
+                    f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,)
+                )
             )
 
         # If a ModelAdmin has list instances of js and css
@@ -251,7 +258,7 @@ class TestAdminMedia(BaseTestAdmin):
         UserAdmin.Media.js = list()
         _add_object_notification_widget()
         response = self.client.get(
-            reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+            reverse(f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,))
         )
 
         # If ModelAdmin has empty attributes
@@ -259,6 +266,6 @@ class TestAdminMedia(BaseTestAdmin):
         UserAdmin.Media.css = {}
         _add_object_notification_widget()
         response = self.client.get(
-            reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+            reverse(f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,))
         )
         UserAdmin.Media = None

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -66,6 +66,7 @@ notification_queryset = Notification.objects.order_by("-timestamp")
 
 class TestNotifications(TestOrganizationMixin, TransactionTestCase):
     app_label = "openwisp_notifications"
+    users_app_label = "openwisp_users"
 
     def setUp(self):
         self.admin = self._create_admin()
@@ -377,7 +378,9 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         expected_output = (
             '<p><a href="https://example.com{user_path}">admin</a></p>'
         ).format(
-            user_path=reverse("admin:openwisp_users_user_change", args=[self.admin.pk])
+            user_path=reverse(
+                f"admin:{self.users_app_label}_user_change", args=[self.admin.pk]
+            )
         )
         self.assertEqual(n.message, expected_output)
         self.assertEqual(n.rendered_description, expected_output)
@@ -435,7 +438,9 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
 
         with self.subTest("Links in notification message"):
             url = _get_absolute_url(
-                reverse("admin:openwisp_users_user_change", args=(self.admin.pk,))
+                reverse(
+                    f"admin:{self.users_app_label}_user_change", args=(self.admin.pk,)
+                )
             )
             message = (
                 "<p>info : None message template verb </p>\n"


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Solves part of #369 . More changes seems required...

## Description of Changes

I set `user_app_label` to `"openwisp_users"` in TestCases that required it.
The same way I saw it done in controller and other modules...

I think this is the first step to avoid copy-pasting too much test code when extending `openwisp-users` and `openwisp-notifications`
