### PR TITLE
[change] Remove unnecessary TEMPLATE DIRS in settings.py

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -207,14 +207,6 @@ if os.environ.get("SAMPLE_APP", False):
     OPENWISP_NOTIFICATIONS_NOTIFICATIONSETTING_MODEL = (
         "sample_notifications.NotificationSetting"
     )
-    TEMPLATES[0]["DIRS"] = [
-        os.path.join(BASE_DIR, "sample_notifications", "templates"),
-        os.path.join(
-            os.path.dirname(os.path.dirname(BASE_DIR)),
-            "openwisp_notifications",
-            "templates",
-        ),
-    ]
     OPENWISP_NOTIFICATIONS_IGNOREOBJECTNOTIFICATION_MODEL = (
         "sample_notifications.IgnoreObjectNotification"
     )

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -94,8 +94,8 @@ TEMPLATES = [
         "OPTIONS": {
             "loaders": [
                 "django.template.loaders.filesystem.Loader",
-                "django.template.loaders.app_directories.Loader",
                 "openwisp_utils.loaders.DependencyLoader",
+                "django.template.loaders.app_directories.Loader",
             ],
             "context_processors": [
                 "django.template.context_processors.debug",


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

It seems the setting `TEMPLATE[0]["DIRS"]` is unnecessary, since we are using loaders to resolve templates.

Also looking at [the docs] (https://docs.djangoproject.com/en/5.2/howto/overriding-templates/#overriding-from-the-project-s-templates-directory) it seems this setting does not apply to the current situation (django project template override vs extended app template)

And finally, imho, it makes it even harder to understand  what one needs to do to write an `openwisp-notifications-extended` app with templates that work as expected...

I removed that setting on my machine and tests still pass... But I m not used to django and might have misunderstood something ? or it might be something needed for an old version of django only ?



