### PR TITLE
[fix] Restrict notification widget to admin and notification preferences page only

### DIFF
--- a/openwisp_notifications/templates/admin/base_site.html
+++ b/openwisp_notifications/templates/admin/base_site.html
@@ -11,11 +11,9 @@
 
 {% block extrahead %}
   {{ block.super }}
-  {% if request|should_load_notifications_widget %}
-    {% if not media.js and 'jquery' not in block.super %}
-      <script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>
-      <script src="{% static 'admin/js/jquery.init.js' %}"></script>
-    {% endif %}
+  {% if request|should_load_notifications_widget and not media.js and 'jquery' not in block.super %}
+    <script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>
+    <script src="{% static 'admin/js/jquery.init.js' %}"></script>
   {% endif %}
 {% endblock %}
 

--- a/openwisp_notifications/templates/admin/base_site.html
+++ b/openwisp_notifications/templates/admin/base_site.html
@@ -3,21 +3,25 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static 'openwisp-notifications/css/loader.css' %}" />
-  <link rel="stylesheet" type="text/css" href="{% static 'openwisp-notifications/css/notifications.css' %}" />
+  {% if request|should_load_notifications_widget %}
+    <link rel="stylesheet" type="text/css" href="{% static 'openwisp-notifications/css/loader.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'openwisp-notifications/css/notifications.css' %}" />
+  {% endif %}
 {% endblock extrastyle %}
 
 {% block extrahead %}
   {{ block.super }}
-  {% if not media.js and 'jquery' not in block.super %}
-    <script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>
-    <script src="{% static 'admin/js/jquery.init.js' %}"></script>
+  {% if request|should_load_notifications_widget %}
+    {% if not media.js and 'jquery' not in block.super %}
+      <script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>
+      <script src="{% static 'admin/js/jquery.init.js' %}"></script>
+    {% endif %}
   {% endif %}
 {% endblock %}
 
 {% block user-tools %}
   {{ block.super }}
-  {% if request.path|slice:":6" == "/admin" or request.path|slice:":14" == "/notifications" %}
+  {% if request|should_load_notifications_widget %}
     <button class="ow-notifications toggle-btn" id="openwisp_notifications">
       <span id="ow-notification-btn"></span>
       {% unread_notifications %}
@@ -26,8 +30,12 @@
     <div class="ow-notification-toast-wrapper"></div>
     <div class="ow-notification-dropdown ow-hide">
       <div class="filters">
-        <span class="toggle-btn" id="ow-mark-all-read" tabindex="0" role="button">{% trans 'Mark all as read' %}</span>
-        <a class="toggle-btn" href="{% url 'notifications:notification_preference' %}">{% trans 'Notification Preferences' %}</a>
+        <span class="toggle-btn" id="ow-mark-all-read" tabindex="0" role="button">
+          {% trans 'Mark all as read' %}
+        </span>
+        <a class="toggle-btn" href="{% url 'notifications:notification_preference' %}">
+          {% trans 'Notification Preferences' %}
+        </a>
       </div>
       <div class="ow-notification-wrapper ow-round-bottom-border">
         <div id="ow-notifications-loader" class="ow-hide"><div class="loader"></div></div>
@@ -40,47 +48,45 @@
 {% endblock  %}
 
 {% block footer %}
-  <div class="ow-overlay ow-overlay-notification ow-overlay-inner ow-hide">
-      <div class="ow-dialog-notification">
-          <span class="ow-dialog-close ow-dialog-close-x">&times;</span>
-          <div class="ow-notification-level-wrapper ow-dialog-notification-level-wrapper"></div>
-          <h2 class="ow-message-title"></h2>
-          <div class="ow-message-description"></div>
-          <div class="ow-dialog-buttons">
-            <button class="ow-message-target-redirect ow-hide button default success-btn">
-              {% trans 'Open' %}
-            </button>
-            <button class="ow-dialog-close button default">
-              {% trans 'Close' %}
-            </button>
-          </div>
-      </div>
-  </div>
   {{ block.super }}
-  {% if request.user.is_authenticated %}
-    {% if request.path|slice:":6" == "/admin" or request.path|slice:":14" == "/notifications" %}
-      <script type="text/javascript" src="{% static 'openwisp-notifications/js/vendor/reconnecting-websocket.min.js' %}"></script>
-      <script type="text/javascript">
-        {% if OPENWISP_NOTIFICATIONS_HOST %}
-          const notificationApiHost = new URL('{{ OPENWISP_NOTIFICATIONS_HOST }}');
-        {% else %}
-          const notificationApiHost = window.location;
-        {% endif %}
-        const webSocketProtocol = notificationApiHost.protocol === 'http:' ? 'ws' : 'wss';
-        const notificationSound = new Audio('{{ OPENWISP_NOTIFICATIONS_SOUND | default:"" }}');
-        // Create websocket connection
-        const notificationSocket = new ReconnectingWebSocket(
-            `${webSocketProtocol}://${notificationApiHost.host}/ws/notification/`,
-            null, {
-                debug: false,
-                // The library re-connects if it fails to establish a connection in "timeoutInterval".
-                // On slow internet connections, the default value of "timeoutInterval" will
-                // keep terminating and re-establishing the connection.
-                timeoutInterval: 7000,
-            }
-        );
-      </script>
-      <script type="text/javascript" src="{% static 'openwisp-notifications/js/notifications.js' %}"></script>
-    {% endif %}
+  {% if request|should_load_notifications_widget %}
+    <div class="ow-overlay ow-overlay-notification ow-overlay-inner ow-hide">
+        <div class="ow-dialog-notification">
+            <span class="ow-dialog-close ow-dialog-close-x">&times;</span>
+            <div class="ow-notification-level-wrapper ow-dialog-notification-level-wrapper"></div>
+            <h2 class="ow-message-title"></h2>
+            <div class="ow-message-description"></div>
+            <div class="ow-dialog-buttons">
+              <button class="ow-message-target-redirect ow-hide button default success-btn">
+                {% trans 'Open' %}
+              </button>
+              <button class="ow-dialog-close button default">
+                {% trans 'Close' %}
+              </button>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript" src="{% static 'openwisp-notifications/js/vendor/reconnecting-websocket.min.js' %}"></script>
+    <script type="text/javascript">
+      {% if OPENWISP_NOTIFICATIONS_HOST %}
+        const notificationApiHost = new URL('{{ OPENWISP_NOTIFICATIONS_HOST }}');
+      {% else %}
+        const notificationApiHost = window.location;
+      {% endif %}
+      const webSocketProtocol = notificationApiHost.protocol === 'http:' ? 'ws' : 'wss';
+      const notificationSound = new Audio('{{ OPENWISP_NOTIFICATIONS_SOUND | default:"" }}');
+      // Create websocket connection
+      const notificationSocket = new ReconnectingWebSocket(
+          `${webSocketProtocol}://${notificationApiHost.host}/ws/notification/`,
+          null, {
+              debug: false,
+              // The library re-connects if it fails to establish a connection in "timeoutInterval".
+              // On slow internet connections, the default value of "timeoutInterval" will
+              // keep terminating and re-establishing the connection.
+              timeoutInterval: 7000,
+          }
+      );
+    </script>
+    <script type="text/javascript" src="{% static 'openwisp-notifications/js/notifications.js' %}"></script>
   {% endif %}
 {% endblock footer %}

--- a/openwisp_notifications/templates/admin/base_site.html
+++ b/openwisp_notifications/templates/admin/base_site.html
@@ -17,24 +17,26 @@
 
 {% block user-tools %}
   {{ block.super }}
-  <button class="ow-notifications toggle-btn" id="openwisp_notifications">
-    <span id="ow-notification-btn"></span>
-    {% unread_notifications %}
-  </button>
-  {% csrf_token %}
-  <div class="ow-notification-toast-wrapper"></div>
-  <div class="ow-notification-dropdown ow-hide">
-    <div class="filters">
-      <span class="toggle-btn" id="ow-mark-all-read" tabindex="0" role="button">{% trans 'Mark all as read' %}</span>
-      <a class="toggle-btn" href="{% url 'notifications:notification_preference' %}">{% trans 'Notification Preferences' %}</a>
+  {% if request.path|slice:":6" == "/admin" or request.path|slice:":14" == "/notifications" %}
+    <button class="ow-notifications toggle-btn" id="openwisp_notifications">
+      <span id="ow-notification-btn"></span>
+      {% unread_notifications %}
+    </button>
+    {% csrf_token %}
+    <div class="ow-notification-toast-wrapper"></div>
+    <div class="ow-notification-dropdown ow-hide">
+      <div class="filters">
+        <span class="toggle-btn" id="ow-mark-all-read" tabindex="0" role="button">{% trans 'Mark all as read' %}</span>
+        <a class="toggle-btn" href="{% url 'notifications:notification_preference' %}">{% trans 'Notification Preferences' %}</a>
+      </div>
+      <div class="ow-notification-wrapper ow-round-bottom-border">
+        <div id="ow-notifications-loader" class="ow-hide"><div class="loader"></div></div>
+      </div>
+      <div class="ow-no-notifications ow-round-bottom-border ow-hide">
+          <p>{% trans 'No new notification.' %}</p>
+      </div>
     </div>
-    <div class="ow-notification-wrapper ow-round-bottom-border">
-      <div id="ow-notifications-loader" class="ow-hide"><div class="loader"></div></div>
-    </div>
-    <div class="ow-no-notifications ow-round-bottom-border ow-hide">
-        <p>{% trans 'No new notification.' %}</p>
-    </div>
-  </div>
+  {% endif %}
 {% endblock  %}
 
 {% block footer %}
@@ -56,27 +58,29 @@
   </div>
   {{ block.super }}
   {% if request.user.is_authenticated %}
-    <script type="text/javascript" src="{% static 'openwisp-notifications/js/vendor/reconnecting-websocket.min.js' %}"></script>
-    <script type="text/javascript">
-      {% if OPENWISP_NOTIFICATIONS_HOST %}
-        const notificationApiHost = new URL('{{ OPENWISP_NOTIFICATIONS_HOST }}');
-      {% else %}
-        const notificationApiHost = window.location;
-      {% endif %}
-      const webSocketProtocol = notificationApiHost.protocol === 'http:' ? 'ws' : 'wss';
-      const notificationSound = new Audio('{{ OPENWISP_NOTIFICATIONS_SOUND | default:"" }}');
-      // Create websocket connection
-      const notificationSocket = new ReconnectingWebSocket(
-          `${webSocketProtocol}://${notificationApiHost.host}/ws/notification/`,
-          null, {
-              debug: false,
-              // The library re-connects if it fails to establish a connection in "timeoutInterval".
-              // On slow internet connections, the default value of "timeoutInterval" will
-              // keep terminating and re-establishing the connection.
-              timeoutInterval: 7000,
-          }
-      );
-    </script>
-    <script type="text/javascript" src="{% static 'openwisp-notifications/js/notifications.js' %}"></script>
+    {% if request.path|slice:":6" == "/admin" or request.path|slice:":14" == "/notifications" %}
+      <script type="text/javascript" src="{% static 'openwisp-notifications/js/vendor/reconnecting-websocket.min.js' %}"></script>
+      <script type="text/javascript">
+        {% if OPENWISP_NOTIFICATIONS_HOST %}
+          const notificationApiHost = new URL('{{ OPENWISP_NOTIFICATIONS_HOST }}');
+        {% else %}
+          const notificationApiHost = window.location;
+        {% endif %}
+        const webSocketProtocol = notificationApiHost.protocol === 'http:' ? 'ws' : 'wss';
+        const notificationSound = new Audio('{{ OPENWISP_NOTIFICATIONS_SOUND | default:"" }}');
+        // Create websocket connection
+        const notificationSocket = new ReconnectingWebSocket(
+            `${webSocketProtocol}://${notificationApiHost.host}/ws/notification/`,
+            null, {
+                debug: false,
+                // The library re-connects if it fails to establish a connection in "timeoutInterval".
+                // On slow internet connections, the default value of "timeoutInterval" will
+                // keep terminating and re-establishing the connection.
+                timeoutInterval: 7000,
+            }
+        );
+      </script>
+      <script type="text/javascript" src="{% static 'openwisp-notifications/js/notifications.js' %}"></script>
+    {% endif %}
   {% endif %}
 {% endblock footer %}

--- a/openwisp_notifications/templatetags/notification_tags.py
+++ b/openwisp_notifications/templatetags/notification_tags.py
@@ -35,7 +35,7 @@ def unread_notifications(context):
     return output
 
 
-@register.filter(name="should_load_notifications_widget")
+@register.filter
 def should_load_notifications_widget(request):
     if not hasattr(request, "user"):
         return False

--- a/openwisp_notifications/templatetags/notification_tags.py
+++ b/openwisp_notifications/templatetags/notification_tags.py
@@ -35,4 +35,13 @@ def unread_notifications(context):
     return output
 
 
+@register.filter(name="should_load_notifications_widget")
+def should_load_notifications_widget(request):
+    if not hasattr(request, "user"):
+        return False
+    return request.user.is_authenticated and request.path.startswith(
+        ("/admin", "/notifications")
+    )
+
+
 register.simple_tag(takes_context=True)(unread_notifications)

--- a/openwisp_notifications/tests/test_base_site_override.py
+++ b/openwisp_notifications/tests/test_base_site_override.py
@@ -7,8 +7,9 @@ User = get_user_model()
 
 class TestBaseSiteOverride(TestCase):
     """
-    Ensures notification widget and websocket scripts are only loaded
-    on admin and notifications pages, not on other pages (e.g., allauth).
+    Checks that the notification widget and its assets
+    are only shown on admin and notifications pages,
+    and not on unrelated pages like allauth login.
     """
 
     def setUp(self):
@@ -18,49 +19,53 @@ class TestBaseSiteOverride(TestCase):
             password="password",
         )
 
-    def test_admin_page_includes_notification_widget_and_scripts(self):
+    def test_admin_page_includes_notification_widget_and_assets(self):
         self.client.force_login(self.admin)
-        # Admin index page
         response = self.client.get(reverse("admin:index"))
-        # Notification widget button
+        content = response.content.decode()
+
         self.assertContains(response, 'id="openwisp_notifications"')
-        # ReconnectingWebSocket script
+        self.assertContains(response, "openwisp-notifications/css/notifications.css")
+        self.assertIn("admin/js/vendor/jquery/jquery.min.js", content)
+        self.assertContains(
+            response, "openwisp-notifications/js/vendor/reconnecting-websocket.min.js"
+        )
+        self.assertContains(response, "openwisp-notifications/js/notifications.js")
         self.assertContains(
             response,
-            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
-        )
-        # Notifications JS
-        self.assertContains(
-            response, "/static/openwisp-notifications/js/notifications.js"
+            'class="ow-overlay ow-overlay-notification ow-overlay-inner ow-hide"',
         )
 
-    def test_notifications_page_includes_notification_widget_and_scripts(self):
+    def test_notifications_page_includes_notification_widget_and_assets(self):
         self.client.force_login(self.admin)
-        # Notifications preferences page
         url = reverse("notifications:notification_preference")
         response = self.client.get(url)
-        # Notification widget button
+        content = response.content.decode()
+
         self.assertContains(response, 'id="openwisp_notifications"')
-        # ReconnectingWebSocket script
+        self.assertContains(response, "openwisp-notifications/css/notifications.css")
+        self.assertIn("admin/js/vendor/jquery/jquery.min.js", content)
+        self.assertContains(
+            response, "openwisp-notifications/js/vendor/reconnecting-websocket.min.js"
+        )
+        self.assertContains(response, "openwisp-notifications/js/notifications.js")
         self.assertContains(
             response,
-            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
-        )
-        # Notifications JS
-        self.assertContains(
-            response, "/static/openwisp-notifications/js/notifications.js"
+            'class="ow-overlay ow-overlay-notification ow-overlay-inner ow-hide"',
         )
 
-    def test_allauth_pages_exclude_notification_widget_and_scripts(self):
-        # allauth login page
+    def test_allauth_pages_exclude_notification_widget_and_assets(self):
         response = self.client.get(reverse("account_login"))
-        # Notification widget should not be present
+        content = response.content.decode()
+
         self.assertNotContains(response, 'id="openwisp_notifications"')
-        # Scripts should not be present
-        self.assertNotContains(
-            response,
-            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
+        self.assertNotIn("openwisp-notifications/css/notifications.css", content)
+        self.assertNotIn("admin/js/vendor/jquery/jquery.min.js", content)
+        self.assertNotIn(
+            "openwisp-notifications/js/vendor/reconnecting-websocket.min.js", content
         )
-        self.assertNotContains(
-            response, "/static/openwisp-notifications/js/notifications.js"
+        self.assertNotIn("openwisp-notifications/js/notifications.js", content)
+        self.assertNotIn(
+            'class="ow-overlay ow-overlay-notification ow-overlay-inner ow-hide"',
+            content,
         )

--- a/openwisp_notifications/tests/test_base_site_override.py
+++ b/openwisp_notifications/tests/test_base_site_override.py
@@ -1,0 +1,66 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+
+class TestBaseSiteOverride(TestCase):
+    """
+    Ensures notification widget and websocket scripts are only loaded
+    on admin and notifications pages, not on other pages (e.g., allauth).
+    """
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="password",
+        )
+
+    def test_admin_page_includes_notification_widget_and_scripts(self):
+        self.client.force_login(self.admin)
+        # Admin index page
+        response = self.client.get(reverse("admin:index"))
+        # Notification widget button
+        self.assertContains(response, 'id="openwisp_notifications"')
+        # ReconnectingWebSocket script
+        self.assertContains(
+            response,
+            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
+        )
+        # Notifications JS
+        self.assertContains(
+            response, "/static/openwisp-notifications/js/notifications.js"
+        )
+
+    def test_notifications_page_includes_notification_widget_and_scripts(self):
+        self.client.force_login(self.admin)
+        # Notifications preferences page
+        url = reverse("notifications:notification_preference")
+        response = self.client.get(url)
+        # Notification widget button
+        self.assertContains(response, 'id="openwisp_notifications"')
+        # ReconnectingWebSocket script
+        self.assertContains(
+            response,
+            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
+        )
+        # Notifications JS
+        self.assertContains(
+            response, "/static/openwisp-notifications/js/notifications.js"
+        )
+
+    def test_allauth_pages_exclude_notification_widget_and_scripts(self):
+        # allauth login page
+        response = self.client.get(reverse("account_login"))
+        # Notification widget should not be present
+        self.assertNotContains(response, 'id="openwisp_notifications"')
+        # Scripts should not be present
+        self.assertNotContains(
+            response,
+            "/static/openwisp-notifications/js/vendor/reconnecting-websocket.min.js",
+        )
+        self.assertNotContains(
+            response, "/static/openwisp-notifications/js/notifications.js"
+        )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #271 

## Description of Changes

Restrict notification widget to admin and notification preferences page only