### PR TITLE
[change] Batch email notification: restore single notification email #396

### DIFF
--- a/docs/user/web-email-notifications.rst
+++ b/docs/user/web-email-notifications.rst
@@ -79,6 +79,11 @@ high volumes.
   batch.
 - After sending the batch email, the system starts queuing new
   notifications for the next batch.
+- If the time since the last email is greater than
+  :ref:`OPENWISP_NOTIFICATIONS_EMAIL_BATCH_INTERVAL
+  <openwisp_notifications_email_batch_interval>`, the new notification is
+  sent instantly as a single notification email. Batching is used only if
+  more notifications arrive within that time window.
 - Only unread notifications are included in the batch. This check is
   performed at the time the batch is sent, ensuring that users don't
   receive emails for alerts they've already seen.

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -224,9 +224,9 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.admin.email])
         n = notification_queryset.first()
-        self.assertIn(
-            "[example.com] 1 unread notification since",
+        self.assertEqual(
             mail.outbox[0].subject,
+            "Test Email subject",
         )
         self.assertIn(n.message, mail.outbox[0].body)
         self.assertIn(n.data.get("url"), mail.outbox[0].body)
@@ -331,9 +331,9 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
     def test_description_in_email_subject(self):
         self.notification_options.pop("email_subject")
         self._create_notification()
-        self.assertIn(
-            "[example.com] 1 unread notification since",
+        self.assertEqual(
             mail.outbox[0].subject,
+            "Test Notification",
         )
 
     def test_handler_optional_tag(self):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #396

## Description

If there's only one notification in the batch, use the Notification.email_subject for the email subject and title.

