### PR TITLE
[chores] Updated HTML email title for single email notification

### DIFF
--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -231,6 +231,10 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         self.assertIn(n.message, mail.outbox[0].body)
         self.assertIn(n.data.get("url"), mail.outbox[0].body)
         self.assertIn("https://", n.data.get("url"))
+        html_email = mail.outbox[0].alternatives[0][0]
+        self.assertIn(
+            '<div class="email-title">1 unread notification</div>', html_email
+        )
 
     def test_email_disabled(self):
         self.notification_options.update(

--- a/openwisp_notifications/utils.py
+++ b/openwisp_notifications/utils.py
@@ -106,13 +106,16 @@ def send_notification_email(
         "footer": get_unsubscribe_url_email_footer(unsubscribe_url),
         "subtitle": _("Since {since}").format(since=since),
         "since": since,
+        "title": _("{notifications_count} unread {pluralize_notification}").format(
+            notifications_count=notifications_count,
+            pluralize_notification=pluralize_notification,
+        ),
     }
     if notifications_count == 1:
         extra_context.update(
             {
                 "call_to_action_url": unsent_notifications[0].url,
                 "call_to_action_text": _("View Details"),
-                "title": unsent_notifications[0].email_subject,
             }
         )
         subject = unsent_notifications[0].email_subject
@@ -134,16 +137,6 @@ def send_notification_email(
             notifications_count=notifications_count,
             since=since,
             pluralize_notification=pluralize_notification,
-        )
-        extra_context.update(
-            {
-                "title": _(
-                    "{notifications_count} unread {pluralize_notification}"
-                ).format(
-                    notifications_count=notifications_count,
-                    pluralize_notification=pluralize_notification,
-                ),
-            }
         )
 
     plain_text_content = render_to_string(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

The title for the HTML email will contain "1 unread notitfication" while the email subject will use the Notification.email_subject.

