### PR TITLE
[fix] Ensure notification widget closes only on user-initiated clicks

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/notifications.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/notifications.js
@@ -64,6 +64,8 @@ function initNotificationDropDown($) {
   $(document).click(function (e) {
     e.stopPropagation();
     if (
+      // Only hide the widget on user-initiated clicks; ignore programmatic clicks
+      e.originalEvent?.isTrusted &&
       // Check if the clicked area is dropDown
       $(".ow-notification-dropdown").has(e.target).length === 0 &&
       // Check notification-btn or not


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/openwisp-notifications/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Bug:
The notifications.js file registers a click handler that closes the widget when the user clicks outside it. However, the handler was also triggered by programmatically dispatched click events in JavaScript, causing unintended widget closures.

Fix:
Check `event.originalEvent.isTrusted` to confirm that the click event originated from an actual user action before closing the widget.

