### PR TITLE
[fix] Corrected get_setting function to properly retrieve settings

### DIFF
--- a/openwisp_notifications/settings.py
+++ b/openwisp_notifications/settings.py
@@ -16,7 +16,7 @@ def get_setting(name, default=None):
     """
     Get a setting from the Django settings module or return a default value.
     """
-    return getattr(f"OPENWISP_NOTIFICATIONS_{name}", name, default)
+    return getattr(settings, f"OPENWISP_NOTIFICATIONS_{name}", default)
 
 
 HOST = get_setting("HOST", None)
@@ -53,7 +53,7 @@ SOUND = re.sub("^/static/", "", SOUND)
 
 
 def get_config():
-    user_config = getattr(settings, "OPENWISP_NOTIFICATIONS_CONFIG", {})
+    user_config = get_setting("CONFIG", {})
     config = CONFIG_DEFAULTS.copy()
     config.update(user_config)
     return config


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Bug:
The `openwisp_notifications.settings.get_setting` function was not reading the value from Django settings. Thus, it was not using the setting defined in the Django projects.

