### PR TITLE
[fix] Disconnect websocket on page reload to prevent missed notificat…

### DIFF
--- a/openwisp_notifications/static/openwisp-notifications/js/notifications.js
+++ b/openwisp_notifications/static/openwisp-notifications/js/notifications.js
@@ -32,6 +32,10 @@ const owNotificationWindow = {
     // closing the window
     $(window).on("beforeunload", function () {
       owNotificationWindow.remove();
+      // Disconnect websocket to prevent missed notifications during page reload
+      if (typeof notificationSocket !== "undefined") {
+        notificationSocket.close();
+      }
     });
     // Get authority to play notification sound when
     // other windows are closed


### PR DESCRIPTION


When users click "Save" or "Save and Continue", the page reloads and closes the websocket connection. If a background task completes during this reload, the notification is lost because there's no active websocket connection to receive it.


Fixes #264

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #264 .


## Description of Changes
Added websocket disconnection in the `beforeunload` event handler. This
   ensures the server knows the client is unavailable and will queue notifications.
  When the page reloads and the websocket reconnects, any queued notifications will be
  delivered properly

## Screenshot

Please include any relevant screenshots.
