### PR TITLE
[fix] Fixed multiple bugs with notification preferences #448

### DIFF
--- a/docs/user/notification-preferences.rst
+++ b/docs/user/notification-preferences.rst
@@ -23,30 +23,55 @@ screenshot below:
 Alternatively, you can also visit ``/notification/preferences/`` to manage
 your settings.
 
+Preference Resolution
+---------------------
+
+Notification preferences are resolved using the following inheritance
+chain:
+
+1. User-specific notification preference
+2. Organization notification preference
+3. Notification type default
+
+A notification setting can therefore either:
+
+- explicitly enable notifications,
+- explicitly disable notifications,
+- or inherit the effective value from organization and notification type
+  defaults.
+
 .. note::
 
     - You can disable notifications globally while still enabling them for
-      specific organizations.
+      specific organizations or notification types.
     - Notification settings are now linked: disabling web notifications
       will automatically disable email notifications, and enabling email
       notifications will automatically enable web notifications.
+    - Notification settings inherit organization and notification type
+      defaults whenever possible instead of storing redundant explicit
+      values.
     - Deleting notification settings is no longer possible via the web
       interface (please use the REST API if removal is needed).
 
-Notification settings are automatically generated for all notification
-types and organizations for every user. Superusers have the ability to
-manage notification settings for all users, including adding or deleting
-them. Meanwhile, staff users can modify their preferred notification
-delivery methods, choosing between receiving notifications via web, email,
-or both. Additionally, users have the option to disable notifications
-entirely by turning off both web and email notification settings.
+Notification settings are automatically generated for notification types
+and organizations associated with a user. Effective notification behavior
+is resolved dynamically using inherited defaults. Superusers have the
+ability to manage notification settings for all users, including adding or
+deleting them. Meanwhile, staff users can modify their preferred
+notification delivery methods, choosing between receiving notifications
+via web, email, or both. Additionally, users have the option to disable
+notifications entirely by turning off both web and email notification
+settings.
 
 .. note::
 
-    If a user has not configured their preferences for email or web
-    notifications for a specific notification type, the system will
-    default to using the ``email_notification`` or ``web_notification``
-    option defined for that notification type.
+    If a user has not explicitly configured a notification preference, the
+    system resolves the effective value using the following order:
+
+    1. User notification preference
+    2. Organization notification preference
+    3. Notification type default (``email_notification`` /
+       ``web_notification``)
 
 Organization Settings
 ---------------------
@@ -72,9 +97,9 @@ notification settings from the **Organization Admin**:
 Key points:
 
 - New users inherit these default settings automatically.
-- Changes apply to all existing users. For example, disabling email
-  notifications at the organization level disables them for all users in
-  the organization.
+- Organization settings act as defaults for all users in the organization.
+- Users inheriting organization defaults will automatically observe
+  organization-level changes.
 - Users can override these defaults by customizing their own notification
   preferences.
 - Organization settings override global defaults defined in Django

--- a/docs/user/notification-preferences.rst
+++ b/docs/user/notification-preferences.rst
@@ -47,9 +47,6 @@ A notification setting can therefore either:
     - Notification settings are now linked: disabling web notifications
       will automatically disable email notifications, and enabling email
       notifications will automatically enable web notifications.
-    - Notification settings inherit organization and notification type
-      defaults whenever possible instead of storing redundant explicit
-      values.
     - Deleting notification settings is no longer possible via the web
       interface (please use the REST API if removal is needed).
 

--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -127,10 +127,14 @@ class BaseNotificationSettingView(GenericAPIView):
         if getattr(self, "swagger_fake_view", False):
             return NotificationSetting.objects.none()  # pragma: no cover
         user_id = self.kwargs.get("user_id", self.request.user.id)
-        return NotificationSetting.objects.exclude(
-            Q(organization__is_active=False)
-            | Q(type__in=app_settings.DISALLOW_PREFERENCES_CHANGE_TYPE)
-        ).filter(user_id=user_id).select_related("organization__notification_settings")
+        return (
+            NotificationSetting.objects.exclude(
+                Q(organization__is_active=False)
+                | Q(type__in=app_settings.DISALLOW_PREFERENCES_CHANGE_TYPE)
+            )
+            .filter(user_id=user_id)
+            .select_related("organization__notification_settings")
+        )
 
 
 class NotificationSettingListView(BaseNotificationSettingView, ListModelMixin):

--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -130,7 +130,7 @@ class BaseNotificationSettingView(GenericAPIView):
         return NotificationSetting.objects.exclude(
             Q(organization__is_active=False)
             | Q(type__in=app_settings.DISALLOW_PREFERENCES_CHANGE_TYPE)
-        ).filter(user_id=user_id)
+        ).filter(user_id=user_id).select_related("organization__notification_settings")
 
 
 class NotificationSettingListView(BaseNotificationSettingView, ListModelMixin):

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -453,13 +453,17 @@ class AbstractNotificationSetting(UUIDModel):
             if self.organization and hasattr(
                 self.organization, "notification_settings"
             ):
-                should_enable_email = (
-                    should_enable_email
-                    and self.organization.notification_settings.email
-                )
-                should_enabled_web = (
-                    should_enabled_web and self.organization.notification_settings.web
-                )
+                if self.organization.notification_settings.web is not None:
+                    should_enabled_web = (
+                        should_enabled_web
+                        and self.organization.notification_settings.web
+                    )
+                if self.organization.notification_settings.email is not None:
+                    should_enable_email = (
+                        should_enable_email
+                        and self.organization.notification_settings.email
+                    )
+
             if self.email == should_enable_email:
                 self.email = None
             if self.web == should_enabled_web:

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -557,27 +557,4 @@ class AbstractOrganizationNotificationSettings(models.Model):
     def save(self, *args, **kwargs):
         if not self.web:
             self.email = False
-        if not self._state.adding:
-            self._update_organizationuser_settings()
         return super().save(*args, **kwargs)
-
-    def _update_organizationuser_settings(self):
-        try:
-            db_instance = self.__class__.objects.only("web", "email").get(
-                organization_id=self.organization_id
-            )
-        except self.__class__.DoesNotExist:
-            return
-        update_fields = {}
-        for field in ["web", "email"]:
-            if getattr(self, field) != getattr(db_instance, field):
-                update_fields[field] = getattr(self, field)
-        if update_fields:
-            NotificationSetting = swapper.load_model(
-                "openwisp_notifications", "NotificationSetting"
-            )
-            transaction.on_commit(
-                lambda: NotificationSetting.objects.filter(
-                    organization_id=self.organization_id
-                ).update(**update_fields)
-            )

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -446,27 +446,22 @@ class AbstractNotificationSetting(UUIDModel):
 
     def normalize_settings(self):
         if self.web_notification is False:
-            self.email = self.web_notification
+            self.email = False
         if self.organization and self.type:
             should_enable_email = self.type_config["email_notification"]
-            should_enabled_web = self.type_config["web_notification"]
-            if self.organization and hasattr(
-                self.organization, "notification_settings"
-            ):
-                if self.organization.notification_settings.web is not None:
-                    should_enabled_web = (
-                        should_enabled_web
-                        and self.organization.notification_settings.web
-                    )
-                if self.organization.notification_settings.email is not None:
-                    should_enable_email = (
-                        should_enable_email
-                        and self.organization.notification_settings.email
-                    )
+            should_enable_web = self.type_config["web_notification"]
+            if hasattr(self.organization, "notification_settings"):
+                should_enable_web = (
+                    should_enable_web and self.organization.notification_settings.web
+                )
+                should_enable_email = (
+                    should_enable_email
+                    and self.organization.notification_settings.email
+                )
 
             if self.email == should_enable_email:
                 self.email = None
-            if self.web == should_enabled_web:
+            if self.web == should_enable_web:
                 self.web = None
 
     def save(self, *args, **kwargs):
@@ -474,20 +469,22 @@ class AbstractNotificationSetting(UUIDModel):
         with transaction.atomic():
             if not self.organization and not self.type:
                 try:
-                    previous_state = self.__class__.objects.only("email").get(
+                    previous_state = self.__class__.objects.only("email", "web").get(
                         pk=self.pk
                     )
-                    updates = {"web": self.web}
+                    updates = {}
+
+                    if self.web != previous_state.web:
+                        updates["web"] = None if self.web is True else self.web
 
                     # If global web notifications are disabled, then disable email notifications as well
                     if self.web is False:
                         updates["email"] = False
-
-                    # Update email notifiations only if it's different from the previous state
+                    # Update email notifications only if it's different from the previous state
                     # Otherwise, it would overwrite the email notification settings for specific
                     # setting that were enabled by the user after disabling global email notifications
-                    if self.email != previous_state.email:
-                        updates["email"] = self.email
+                    elif self.email != previous_state.email:
+                        updates["email"] = None if self.email is True else self.email
 
                     self.user.notificationsetting_set.exclude(pk=self.pk).update(
                         **updates
@@ -510,11 +507,7 @@ class AbstractNotificationSetting(UUIDModel):
         if self.email is not None:
             return self.email
         email_enabled = self.type_config.get("email_notification")
-        if (
-            self.organization
-            and hasattr(self.organization, "notification_settings")
-            and self.organization.notification_settings.email is not None
-        ):
+        if self.organization and hasattr(self.organization, "notification_settings"):
             email_enabled = (
                 email_enabled and self.organization.notification_settings.email
             )
@@ -525,11 +518,7 @@ class AbstractNotificationSetting(UUIDModel):
         if self.web is not None:
             return self.web
         web_enabled = self.type_config.get("web_notification")
-        if (
-            self.organization
-            and hasattr(self.organization, "notification_settings")
-            and self.organization.notification_settings.web is not None
-        ):
+        if self.organization and hasattr(self.organization, "notification_settings"):
             web_enabled = web_enabled and self.organization.notification_settings.web
         return web_enabled
 

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -456,8 +456,8 @@ class AbstractNotificationSetting(UUIDModel):
             - True/False: explicit user override notification settings.
             - None: inherit effective value from organization/type defaults.
 
-        Explicit enabled states are collapsed to ``None`` whenever they
-        match the inherited effective value, avoiding redundant storage.
+        Explicit enabled states are collapsed to ``None`` whenever they match
+        the inherited effective value, avoiding redundant storage.
 
         Email notifications cannot be enabled when web notifications are
         effectively disabled.
@@ -476,9 +476,13 @@ class AbstractNotificationSetting(UUIDModel):
                     and self.organization.notification_settings.email
                 )
 
-            if self.email == should_enable_email:
+            if self.email == should_enable_email and not (
+                self.email is False and self.type_config["email_notification"] is True
+            ):
                 self.email = None
-            if self.web == should_enable_web:
+            if self.web == should_enable_web and not (
+                self.web is False and self.type_config["web_notification"] is True
+            ):
                 self.web = None
 
     def save(self, *args, **kwargs):

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -444,9 +444,29 @@ class AbstractNotificationSetting(UUIDModel):
             ):
                 raise ValidationError("There can only be one global setting per user.")
 
-    def save(self, *args, **kwargs):
-        if not self.web_notification:
+    def normalize_settings(self):
+        if self.web_notification is False:
             self.email = self.web_notification
+        if self.organization and self.type:
+            should_enable_email = self.type_config["email_notification"]
+            should_enabled_web = self.type_config["web_notification"]
+            if self.organization and hasattr(
+                self.organization, "notification_settings"
+            ):
+                should_enable_email = (
+                    should_enable_email
+                    and self.organization.notification_settings.email
+                )
+                should_enabled_web = (
+                    should_enabled_web and self.organization.notification_settings.web
+                )
+            if self.email == should_enable_email:
+                self.email = None
+            if self.web == should_enabled_web:
+                self.web = None
+
+    def save(self, *args, **kwargs):
+        self.normalize_settings()
         with transaction.atomic():
             if not self.organization and not self.type:
                 try:
@@ -456,7 +476,7 @@ class AbstractNotificationSetting(UUIDModel):
                     updates = {"web": self.web}
 
                     # If global web notifications are disabled, then disable email notifications as well
-                    if not self.web:
+                    if self.web is False:
                         updates["email"] = False
 
                     # Update email notifiations only if it's different from the previous state
@@ -475,11 +495,6 @@ class AbstractNotificationSetting(UUIDModel):
 
     def full_clean(self, *args, **kwargs):
         self.validate_global_setting()
-        if self.organization and self.type:
-            if self.email == self.type_config["email_notification"]:
-                self.email = None
-            if self.web == self.type_config["web_notification"]:
-                self.web = None
         return super().full_clean(*args, **kwargs)
 
     @property
@@ -490,13 +505,29 @@ class AbstractNotificationSetting(UUIDModel):
     def email_notification(self):
         if self.email is not None:
             return self.email
-        return self.type_config.get("email_notification")
+        email_enabled = self.type_config.get("email_notification")
+        if (
+            self.organization
+            and hasattr(self.organization, "notification_settings")
+            and self.organization.notification_settings.email is not None
+        ):
+            email_enabled = (
+                email_enabled and self.organization.notification_settings.email
+            )
+        return email_enabled
 
     @property
     def web_notification(self):
         if self.web is not None:
             return self.web
-        return self.type_config.get("web_notification")
+        web_enabled = self.type_config.get("web_notification")
+        if (
+            self.organization
+            and hasattr(self.organization, "notification_settings")
+            and self.organization.notification_settings.web is not None
+        ):
+            web_enabled = web_enabled and self.organization.notification_settings.web
+        return web_enabled
 
     @classmethod
     def email_notifications_enabled(cls, user):

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -445,6 +445,23 @@ class AbstractNotificationSetting(UUIDModel):
                 raise ValidationError("There can only be one global setting per user.")
 
     def normalize_settings(self):
+        """
+        Normalize stored notification preferences into sparse overrides.
+
+        Effective notification preferences are resolved through inheritance:
+
+            user setting -> organization setting -> notification type default
+
+        Stored values follow these semantics:
+            - True/False: explicit user override notification settings.
+            - None: inherit effective value from organization/type defaults.
+
+        Explicit enabled states are collapsed to ``None`` whenever they
+        match the inherited effective value, avoiding redundant storage.
+
+        Email notifications cannot be enabled when web notifications are
+        effectively disabled.
+        """
         if self.web_notification is False:
             self.email = False
         if self.organization and self.type:
@@ -504,6 +521,21 @@ class AbstractNotificationSetting(UUIDModel):
 
     @property
     def email_notification(self):
+        """
+        Resolve effective email notification preference.
+
+        Resolution order:
+            1. Explicit user preference stored on this notification setting.
+            2. Organization-level notification preference.
+            3. Notification type default configuration.
+
+        Stored values use sparse inheritance semantics:
+            - True/False: explicitly set by the user.
+            - None: inherit from organization/type defaults.
+
+        Explicit True values are normalized away and represented through
+        inheritance whenever possible.
+        """
         if self.email is not None:
             return self.email
         email_enabled = self.type_config.get("email_notification")
@@ -515,6 +547,21 @@ class AbstractNotificationSetting(UUIDModel):
 
     @property
     def web_notification(self):
+        """
+        Resolve effective web notification preference.
+
+        Resolution order:
+            1. Explicit user preference stored on this notification setting.
+            2. Organization-level notification preference.
+            3. Notification type default configuration.
+
+        Stored values use sparse inheritance semantics:
+            - True/False: explicitly set by the user.
+            - None: inherit from organization/type defaults.
+
+        Explicit True values are normalized away and represented through
+        inheritance whenever possible.
+        """
         if self.web is not None:
             return self.web
         web_enabled = self.type_config.get("web_notification")

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -71,14 +71,7 @@ def notify_handler(**kwargs):
     where = Q(is_superuser=True)
     not_where = Q()
     where_group = Q()
-    org_web = None
     if target_org:
-        org_settings = (
-            OrganizationNotificationSettings.objects.filter(organization_id=target_org)
-            .only("web")
-            .first()
-        )
-        org_web = getattr(org_settings, "web", None)
         org_admin_query = Q(
             **{
                 f"{user_app_name}_organizationuser__organization": target_org,
@@ -88,17 +81,32 @@ def notify_handler(**kwargs):
         where = where | (Q(is_staff=True) & org_admin_query)
         where_group = org_admin_query
 
-        # Notification preference filtering
+        # Notification preference resolution:
+        # user setting -> org setting -> type default.
         #
-        # Resolution order:
-        # user setting -> org setting -> type default
-        #
-        # Users with web=None are included only if the fallback
-        # chain can still resolve to True.
+        # Users with web=None are included only when the fallback
+        # chain can still resolve to True. Org-level web settings
+        # are resolved via JOINs in the main query to avoid an
+        # additional OrganizationNotificationSettings lookup.
         if notification_type:
             web_notification = Q(notificationsetting__web=True)
-            if org_web is not False and notification_template["web_notification"]:
-                web_notification |= Q(notificationsetting__web=None)
+            if notification_template["web_notification"]:
+                # Users with web=None inherit the org setting, so
+                # include them unless the org explicitly disables
+                # web notifications.
+                web_notification |= Q(
+                    notificationsetting__web=None,
+                ) & (
+                    Q(
+                        notificationsetting__organization__notification_settings__web=True
+                    )
+                    | Q(
+                        notificationsetting__organization__notification_settings__web=None
+                    )
+                    | Q(
+                        notificationsetting__organization__notification_settings__isnull=True
+                    )
+                )
 
             notification_setting = web_notification & Q(
                 notificationsetting__type=notification_type,

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -71,7 +71,14 @@ def notify_handler(**kwargs):
     where = Q(is_superuser=True)
     not_where = Q()
     where_group = Q()
+    org_web = None
     if target_org:
+        org_settings = (
+            OrganizationNotificationSettings.objects.filter(organization_id=target_org)
+            .only("web")
+            .first()
+        )
+        org_web = getattr(org_settings, "web", None)
         org_admin_query = Q(
             **{
                 f"{user_app_name}_organizationuser__organization": target_org,
@@ -81,14 +88,16 @@ def notify_handler(**kwargs):
         where = where | (Q(is_staff=True) & org_admin_query)
         where_group = org_admin_query
 
-        # We can only find notification setting if notification type and
-        # target organization is present.
+        # Notification preference filtering
+        #
+        # Resolution order:
+        # user setting -> org setting -> type default
+        #
+        # Users with web=None are included only if the fallback
+        # chain can still resolve to True.
         if notification_type:
-            # Create notification for users who have opted for receiving notifications.
-            # For users who have not configured web_notifications,
-            # use default from notification type
             web_notification = Q(notificationsetting__web=True)
-            if notification_template["web_notification"]:
+            if org_web is True and notification_template["web_notification"]:
                 web_notification |= Q(notificationsetting__web=None)
 
             notification_setting = web_notification & Q(

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -97,7 +97,7 @@ def notify_handler(**kwargs):
         # chain can still resolve to True.
         if notification_type:
             web_notification = Q(notificationsetting__web=True)
-            if org_web is True and notification_template["web_notification"]:
+            if org_web is not False and notification_template["web_notification"]:
                 web_notification |= Q(notificationsetting__web=None)
 
             notification_setting = web_notification & Q(

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -87,13 +87,22 @@ def create_notification_settings(user, organizations, notification_types):
 
     for type in notification_types:
         for org in organizations:
-            try:
-                org_notification_settings = org.notification_settings
-                email = org_notification_settings.email
-                web = org_notification_settings.web
-            except ObjectDoesNotExist:
-                email = app_settings.WEB_ENABLED
-                web = app_settings.EMAIL_ENABLED
+            if global_setting.email is not False and global_setting.web is not False:
+                try:
+                    org_notification_settings = org.notification_settings
+                    email = org_notification_settings.email
+                    web = org_notification_settings.web
+                except ObjectDoesNotExist:
+                    email = app_settings.WEB_ENABLED
+                    web = app_settings.EMAIL_ENABLED
+            if global_setting.email is False:
+                email = False
+            if global_setting.web is False:
+                web = False
+            if email is True:
+                email = None
+            if web is True:
+                web = None
             # If NotificationSetting already exists, then we ensure it is not marked deleted
             updated = NotificationSetting.objects.filter(
                 user=user, type=type, organization=org
@@ -105,8 +114,8 @@ def create_notification_settings(user, organizations, notification_types):
                     user=user,
                     type=type,
                     organization=org,
-                    email=None if email else False,
-                    web=None if web else False,
+                    email=email,
+                    web=web,
                     deleted=False,
                 )
 

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -87,18 +87,22 @@ def create_notification_settings(user, organizations, notification_types):
 
     for type in notification_types:
         for org in organizations:
-            if global_setting.email is not False and global_setting.web is not False:
+            # Any new notification setting shall inherit user's global
+            # notification preferences.
+            email = False if global_setting.email is False else None
+            web = False if global_setting.web is False else None
+            if email is not False or web is not False:
                 try:
                     org_notification_settings = org.notification_settings
-                    email = org_notification_settings.email
-                    web = org_notification_settings.web
+                    org_email = org_notification_settings.email
+                    org_web = org_notification_settings.web
                 except ObjectDoesNotExist:
-                    email = app_settings.WEB_ENABLED
-                    web = app_settings.EMAIL_ENABLED
-            if global_setting.email is False:
-                email = False
-            if global_setting.web is False:
-                web = False
+                    org_email = app_settings.EMAIL_ENABLED
+                    org_web = app_settings.WEB_ENABLED
+                if email is not False:
+                    email = org_email
+                if web is not False:
+                    web = org_web
             if email is True:
                 email = None
             if web is True:

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -92,10 +92,8 @@ def _resolve_initial_notification_setting(global_value, org_value):
     """
     if global_value is False:
         return False
-
     if org_value is False:
         return False
-
     return None
 
 

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -78,6 +78,27 @@ def delete_old_notifications(days):
     ).delete()
 
 
+def _resolve_initial_notification_setting(global_value, org_value):
+    """
+    Resolve initial stored value for a notification preference.
+
+    Stored semantics:
+
+    - False: explicit override disabling notifications
+    - None: inherit effective value from org/type defaults
+
+    We never persist True because enabled/default states are
+    represented through inheritance.
+    """
+    if global_value is False:
+        return False
+
+    if org_value is False:
+        return False
+
+    return None
+
+
 # Following tasks updates notification settings in database.
 # 'ns' is short for notification_setting
 def create_notification_settings(user, organizations, notification_types):
@@ -89,24 +110,22 @@ def create_notification_settings(user, organizations, notification_types):
         for org in organizations:
             # Any new notification setting shall inherit user's global
             # notification preferences.
-            email = False if global_setting.email is False else None
-            web = False if global_setting.web is False else None
-            if email is not False or web is not False:
-                try:
-                    org_notification_settings = org.notification_settings
-                    org_email = org_notification_settings.email
-                    org_web = org_notification_settings.web
-                except ObjectDoesNotExist:
-                    org_email = app_settings.EMAIL_ENABLED
-                    org_web = app_settings.WEB_ENABLED
-                if email is not False:
-                    email = org_email
-                if web is not False:
-                    web = org_web
-            if email is True:
-                email = None
-            if web is True:
-                web = None
+            try:
+                org_notification_settings = org.notification_settings
+                org_email = org_notification_settings.email
+                org_web = org_notification_settings.web
+            except ObjectDoesNotExist:
+                org_email = app_settings.EMAIL_ENABLED
+                org_web = app_settings.WEB_ENABLED
+
+            email = _resolve_initial_notification_setting(
+                global_setting.email,
+                org_email,
+            )
+            web = _resolve_initial_notification_setting(
+                global_setting.web,
+                org_web,
+            )
             # If NotificationSetting already exists, then we ensure it is not marked deleted
             updated = NotificationSetting.objects.filter(
                 user=user, type=type, organization=org

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -668,7 +668,7 @@ class TestNotificationApi(
                 "notification_setting",
                 notification_setting.pk,
             )
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(2):
                 response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             data = response.data

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -426,6 +426,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
         global_setting.web = False
         global_setting.email = False
+        global_setting.full_clean()
         global_setting.save()
         org = self._create_org(name="New Test Org")
         org_setting = NotificationSetting.objects.get(
@@ -457,6 +458,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
         global_setting.web = False
         global_setting.email = False
+        global_setting.full_clean()
         global_setting.save()
         # Updating global setting should update existing org settings
         org1_setting = NotificationSetting.objects.get(

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -417,3 +417,45 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             with self.assertRaises(ValidationError):
                 global_setting.full_clean()
                 global_setting.save()
+
+    def test_new_org_creation_respects_global_preferences(self):
+        admin = self._get_admin()
+        global_setting = NotificationSetting.objects.get(
+            user=admin, organization=None, type=None
+        )
+        global_setting.web = False
+        global_setting.email = False
+        global_setting.save()
+        org = self._create_org(name="New Test Org")
+        org_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="default"
+        )
+        self.assertEqual(org_setting.web, False)
+        self.assertEqual(org_setting.email, False)
+
+    def test_org_admin_addition_respects_global_preferences(self):
+        user = self._get_user()
+        org1 = self._get_org()
+        self._create_org_user(user=user, organization=org1, is_admin=True)
+        # Global notification setting is created only when the user is
+        # admin of atleast one organization.
+        global_setting = NotificationSetting.objects.get(
+            user=user, organization=None, type=None
+        )
+        global_setting.web = False
+        global_setting.email = False
+        global_setting.save()
+        # Updating global setting should update existing org settings
+        org1_setting = NotificationSetting.objects.get(
+            user=user, organization=org1, type="default"
+        )
+        self.assertEqual(org1_setting.web, False)
+        self.assertEqual(org1_setting.email, False)
+        # New organization should also respect global preferences
+        org2 = self._create_org(name="New Test Org")
+        self._create_org_user(user=user, organization=org2, is_admin=True)
+        org2_setting = NotificationSetting.objects.get(
+            user=user, organization=org2, type="default"
+        )
+        self.assertEqual(org2_setting.web, False)
+        self.assertEqual(org2_setting.email, False)

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -444,19 +444,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
                 user=admin, organization=org, type="default"
             )
             self.assertEqual(org_setting.email, False)
-            self.assertEqual(org_setting.web, True)
-
-        with self.subTest("global web=False, email=True"):
-            global_setting.refresh_from_db()
-            global_setting.web = False
-            global_setting.email = True
-            global_setting.save()
-            org = self._create_org(name="Asymmetric Org Web False")
-            org_setting = NotificationSetting.objects.get(
-                user=admin, organization=org, type="default"
-            )
-            self.assertEqual(org_setting.web, False)
-            self.assertEqual(org_setting.email, True)
+            self.assertEqual(org_setting.web, None)
 
     def test_org_admin_addition_respects_global_preferences(self):
         user = self._get_user()
@@ -501,22 +489,4 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
                 user=new_user, organization=org_b, type="default"
             )
             self.assertEqual(org_setting.email, False)
-            self.assertEqual(org_setting.web, True)
-
-        with self.subTest("global web=False, email=True"):
-            new_user = self._create_operator()
-            org_a = self._create_org(name="Asymmetric Add Org C")
-            self._create_org_user(user=new_user, organization=org_a, is_admin=True)
-            new_global = NotificationSetting.objects.get(
-                user=new_user, organization=None, type=None
-            )
-            new_global.web = False
-            new_global.email = True
-            new_global.save()
-            org_b = self._create_org(name="Asymmetric Add Org D")
-            self._create_org_user(user=new_user, organization=org_b, is_admin=True)
-            org_setting = NotificationSetting.objects.get(
-                user=new_user, organization=org_b, type="default"
-            )
-            self.assertEqual(org_setting.web, False)
-            self.assertEqual(org_setting.email, True)
+            self.assertEqual(org_setting.web, None)

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -421,7 +421,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
 
     def test_new_org_creation_respects_global_preferences(self):
         """
-        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        Regression test for bug 1 in https://github.com/openwisp/openwisp-notifications/issues/448
         """
         admin = self._get_admin()
         global_setting = NotificationSetting.objects.get(
@@ -452,7 +452,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
 
     def test_org_admin_addition_respects_global_preferences(self):
         """
-        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        Regression test for bug 2 in https://github.com/openwisp/openwisp-notifications/issues/448
         """
         user = self._get_user()
         org1 = self._get_org()
@@ -501,7 +501,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
 
     def test_org_setting_change_does_not_change_user_overrides(self):
         """
-        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        Regression test for bug 3 in https://github.com/openwisp/openwisp-notifications/issues/448
         """
         admin = self._create_admin()
         org = self._get_org()
@@ -582,3 +582,49 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         generic_setting.refresh_from_db()
         self.assertIsNone(generic_setting.email)
         self.assertEqual(generic_setting.email_notification, False)
+
+    def test_user_explicit_false_not_collapsed_when_type_enabled_default(self):
+        admin = self._get_admin()
+        org = self._get_org()
+        notification_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="default"
+        )
+        self.assertEqual(notification_setting.type_config["email_notification"], True)
+        # User explicitly disables email for this org
+        notification_setting.email = False
+        notification_setting.full_clean()
+        notification_setting.save()
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.email_notification, False)
+        # Toggle organization notification settings
+        org.notification_settings.email = False
+        org.notification_settings.full_clean()
+        org.notification_settings.save()
+        org.notification_settings.email = True
+        org.notification_settings.save()
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.email, False)
+        self.assertEqual(notification_setting.email_notification, False)
+
+    def test_user_explicit_false_not_collapsed_on_web_when_type_enabled(self):
+        admin = self._get_admin()
+        org = self._get_org()
+        notification_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="default"
+        )
+        self.assertEqual(notification_setting.type_config["web_notification"], True)
+        # User explicitly disables web for this org
+        notification_setting.web = False
+        notification_setting.full_clean()
+        notification_setting.save()
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.web_notification, False)
+        # Toggle organization notification settings
+        org.notification_settings.web = False
+        org.notification_settings.full_clean()
+        org.notification_settings.save()
+        org.notification_settings.web = True
+        org.notification_settings.save()
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.web, False)
+        self.assertEqual(notification_setting.web_notification, False)

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -434,6 +434,30 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(org_setting.web, False)
         self.assertEqual(org_setting.email, False)
 
+        with self.subTest("global email=False, web=True"):
+            global_setting.refresh_from_db()
+            global_setting.email = False
+            global_setting.web = True
+            global_setting.save()
+            org = self._create_org(name="Asymmetric Org Email False")
+            org_setting = NotificationSetting.objects.get(
+                user=admin, organization=org, type="default"
+            )
+            self.assertEqual(org_setting.email, False)
+            self.assertEqual(org_setting.web, True)
+
+        with self.subTest("global web=False, email=True"):
+            global_setting.refresh_from_db()
+            global_setting.web = False
+            global_setting.email = True
+            global_setting.save()
+            org = self._create_org(name="Asymmetric Org Web False")
+            org_setting = NotificationSetting.objects.get(
+                user=admin, organization=org, type="default"
+            )
+            self.assertEqual(org_setting.web, False)
+            self.assertEqual(org_setting.email, True)
+
     def test_org_admin_addition_respects_global_preferences(self):
         user = self._get_user()
         org1 = self._get_org()
@@ -460,3 +484,39 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
         self.assertEqual(org2_setting.web, False)
         self.assertEqual(org2_setting.email, False)
+
+        with self.subTest("global email=False, web=True"):
+            new_user = self._create_operator()
+            org_a = self._create_org(name="Asymmetric Add Org A")
+            self._create_org_user(user=new_user, organization=org_a, is_admin=True)
+            new_global = NotificationSetting.objects.get(
+                user=new_user, organization=None, type=None
+            )
+            new_global.email = False
+            new_global.web = True
+            new_global.save()
+            org_b = self._create_org(name="Asymmetric Add Org B")
+            self._create_org_user(user=new_user, organization=org_b, is_admin=True)
+            org_setting = NotificationSetting.objects.get(
+                user=new_user, organization=org_b, type="default"
+            )
+            self.assertEqual(org_setting.email, False)
+            self.assertEqual(org_setting.web, True)
+
+        with self.subTest("global web=False, email=True"):
+            new_user = self._create_operator()
+            org_a = self._create_org(name="Asymmetric Add Org C")
+            self._create_org_user(user=new_user, organization=org_a, is_admin=True)
+            new_global = NotificationSetting.objects.get(
+                user=new_user, organization=None, type=None
+            )
+            new_global.web = False
+            new_global.email = True
+            new_global.save()
+            org_b = self._create_org(name="Asymmetric Add Org D")
+            self._create_org_user(user=new_user, organization=org_b, is_admin=True)
+            org_setting = NotificationSetting.objects.get(
+                user=new_user, organization=org_b, type="default"
+            )
+            self.assertEqual(org_setting.web, False)
+            self.assertEqual(org_setting.email, True)

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -492,3 +492,56 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             )
             self.assertEqual(org_setting.email, False)
             self.assertEqual(org_setting.web, None)
+
+    def test_global_email_change_does_not_reset_user_web_override(self):
+        admin = self._create_admin()
+        org = self._get_org()
+        global_setting = NotificationSetting.objects.get(
+            user=admin,
+            organization=None,
+            type=None,
+        )
+        global_setting.web = True
+        global_setting.email = True
+        global_setting.full_clean()
+        global_setting.save()
+        notification_setting = NotificationSetting.objects.get(
+            user=admin,
+            organization=org,
+            type="default",
+        )
+        notification_setting.web = False
+        notification_setting.full_clean()
+        notification_setting.save()
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.web, False)
+        # Change only global email preference
+        global_setting.email = False
+        global_setting.full_clean()
+        global_setting.save()
+        # Explicit user override must remain intact
+        notification_setting.refresh_from_db()
+        self.assertEqual(notification_setting.web, False)
+
+    def test_global_toggle_does_not_override_type_email_default(self):
+        admin = self._get_admin()
+        org = self._get_org("default")
+        generic_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="generic_message"
+        )
+        self.assertIsNone(generic_setting.email)
+        self.assertEqual(generic_setting.email_notification, False)
+        # Disable global email so all settings changes to False
+        global_setting = NotificationSetting.objects.get(
+            user=admin, organization=None, type=None
+        )
+        global_setting.email = False
+        global_setting.full_clean()
+        global_setting.save()
+        # Enable email for global setting
+        global_setting.email = True
+        global_setting.full_clean()
+        global_setting.save()
+        generic_setting.refresh_from_db()
+        self.assertIsNone(generic_setting.email)
+        self.assertEqual(generic_setting.email_notification, False)

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -247,6 +247,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         notification_setting = queryset.first()
 
         notification_setting.full_clean()
+        notification_setting.save()
         self.assertIsNone(notification_setting.email)
         self.assertIsNone(notification_setting.web)
 

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -420,6 +420,9 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
                 global_setting.save()
 
     def test_new_org_creation_respects_global_preferences(self):
+        """
+        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        """
         admin = self._get_admin()
         global_setting = NotificationSetting.objects.get(
             user=admin, organization=None, type=None
@@ -448,6 +451,9 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             self.assertEqual(org_setting.web, None)
 
     def test_org_admin_addition_respects_global_preferences(self):
+        """
+        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        """
         user = self._get_user()
         org1 = self._get_org()
         self._create_org_user(user=user, organization=org1, is_admin=True)
@@ -492,6 +498,37 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             )
             self.assertEqual(org_setting.email, False)
             self.assertEqual(org_setting.web, None)
+
+    def test_org_setting_change_does_not_change_user_overrides(self):
+        """
+        Regression test for https://github.com/openwisp/openwisp-notifications/issues/448
+        """
+        admin = self._create_admin()
+        org = self._get_org()
+        global_setting = NotificationSetting.objects.get(
+            user=admin, organization=None, type=None
+        )
+        # User explicitly disables web for this org
+        org_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="default"
+        )
+        org_setting.web = False
+        org_setting.full_clean()
+        org_setting.save()
+        org_setting.refresh_from_db()
+        self.assertEqual(org_setting.web, False)
+
+        # Toggle global web off and back on
+        global_setting.web = False
+        global_setting.full_clean()
+        global_setting.save()
+        global_setting.web = True
+        global_setting.full_clean()
+        global_setting.save()
+        default_type_setting = NotificationSetting.objects.get(
+            user=admin, organization=org, type="default"
+        )
+        self.assertEqual(default_type_setting.web_notification, True)
 
     def test_global_email_change_does_not_reset_user_web_override(self):
         admin = self._create_admin()

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1545,30 +1545,36 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
         mail.outbox.clear()
         cache.delete(Notification.get_user_batched_notifications_cache_key(self.admin))
 
-    def _set_org_notification_settings(self, web=None, email=None):
+    def _set_org_notification_settings(self, **kwargs):
         org_setting = OrganizationNotificationSettings.objects.get(
             organization=self.org
         )
-        org_setting.web = web
-        org_setting.email = email
+        if "web" in kwargs:
+            org_setting.web = kwargs["web"]
+        if "email" in kwargs:
+            org_setting.email = kwargs["email"]
         org_setting.full_clean()
         org_setting.save()
 
-    def _set_user_notification_settings(self, type_name, web=None, email=None):
+    def _set_user_notification_settings(self, type_name, **kwargs):
         ns = NotificationSetting.objects.get(
             user=self.admin, organization=self.org, type=type_name
         )
-        ns.web = web
-        ns.email = email
+        if "web" in kwargs:
+            ns.web = kwargs["web"]
+        if "email" in kwargs:
+            ns.email = kwargs["email"]
         ns.full_clean()
         ns.save()
 
-    def _set_global_notification_settings(self, web=None, email=None):
+    def _set_global_notification_settings(self, **kwargs):
         ns = NotificationSetting.objects.get(
             user=self.admin, type=None, organization=None
         )
-        ns.web = web
-        ns.email = email
+        if "web" in kwargs:
+            ns.web = kwargs["web"]
+        if "email" in kwargs:
+            ns.email = kwargs["email"]
         ns.full_clean()
         ns.save()
 

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -56,6 +56,7 @@ OrganizationUser = swapper_load_model("openwisp_users", "OrganizationUser")
 Group = swapper_load_model("openwisp_users", "Group")
 Notification = load_model("Notification")
 NotificationSetting = load_model("NotificationSetting")
+OrganizationNotificationSettings = load_model("OrganizationNotificationSettings")
 NotificationAppConfig = apps.get_app_config(Notification._meta.app_label)
 # reused across tests
 start_time = timezone.now()
@@ -978,7 +979,8 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             notification_setting.email = True
             notification_setting.save()
             notification_setting.refresh_from_db()
-            self.assertTrue(notification_setting.email)
+            self.assertEqual(notification_setting.email, None)
+            self.assertEqual(notification_setting.email_notification, True)
 
         with self.subTest('Test user web preference is "True"'):
             NotificationSetting.objects.filter(
@@ -1529,6 +1531,298 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         with self.subTest("Test invalid user ID"):
             response = self.client.get(reverse(preference_page, args=(uuid4(),)))
             self.assertEqual(response.status_code, 404)
+
+
+class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
+    app_label = "openwisp_notifications"
+
+    def setUp(self):
+        self.admin = self._create_admin()
+        self.org = self._get_org()
+        self.user = self._get_operator()
+        self.target = self._create_org_user(organization=self.org, user=self.user)
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+
+    def _set_org_notification_settings(self, web=None, email=None):
+        org_setting = OrganizationNotificationSettings.objects.get(
+            organization=self.org
+        )
+        org_setting.web = web
+        org_setting.email = email
+        org_setting.full_clean()
+        org_setting.save()
+
+    def _set_user_notification_settings(self, type_name, web=None, email=None):
+        ns = NotificationSetting.objects.get(
+            user=self.admin, organization=self.org, type=type_name
+        )
+        ns.web = web
+        ns.email = email
+        ns.full_clean()
+        ns.save()
+
+    def _set_global_notification_settings(self, web=None, email=None):
+        ns = NotificationSetting.objects.get(
+            user=self.admin, type=None, organization=None
+        )
+        ns.web = web
+        ns.email = email
+        ns.full_clean()
+        ns.save()
+
+    def _send_notification(self, type_name="default", **kwargs):
+        options = dict(
+            sender=self.admin,
+            type=type_name,
+            target=self.target,
+        )
+        options.update(kwargs)
+        notify.send(
+            **options,
+        )
+
+    def _assert_notification_created(self, expected=True, target=None):
+        if target is None:
+            target = self.target
+        count = Notification.objects.filter(
+            recipient=self.admin,
+            target_object_id=target.pk,
+        ).count()
+        if expected:
+            self.assertEqual(count, 1)
+        else:
+            self.assertEqual(count, 0)
+
+    def _assert_email_sent(self, expected=True):
+        if expected:
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertEqual(mail.outbox[0].to, [self.admin.email])
+        else:
+            self.assertEqual(len(mail.outbox), 0)
+
+    def test_default_type_org_none_user_none(self):
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_generic_type_org_none_user_none(self):
+        self._send_notification("generic_message")
+        self._assert_notification_created(True)
+        self._assert_email_sent(False)
+
+    def test_default_type_org_enabled_user_none(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_default_type_org_disabled_user_none(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_generic_type_org_enabled_user_none(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._send_notification("generic_message")
+        self._assert_notification_created(True)
+        self._assert_email_sent(False)
+
+    def test_generic_type_org_disabled_user_none(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._send_notification("generic_message")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_default_type_org_none_user_enabled(self):
+        self._set_user_notification_settings("default", web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_default_type_org_none_user_disabled(self):
+        self._set_user_notification_settings("default", web=False, email=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_generic_type_org_none_user_enabled(self):
+        self._set_user_notification_settings("generic_message", web=True, email=True)
+        self._send_notification("generic_message")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_generic_type_org_none_user_disabled(self):
+        self._set_user_notification_settings("generic_message", web=False, email=False)
+        self._send_notification("generic_message")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_default_type_org_enabled_user_enabled(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._set_user_notification_settings("default", web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_default_type_org_enabled_user_disabled(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._set_user_notification_settings("default", web=False, email=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_default_type_org_disabled_user_enabled(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._set_user_notification_settings("default", web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_default_type_org_disabled_user_disabled(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._set_user_notification_settings("default", web=False, email=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_generic_type_org_enabled_user_enabled(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._set_user_notification_settings("generic_message", web=True, email=True)
+        self._send_notification("generic_message")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_generic_type_org_enabled_user_disabled(self):
+        self._set_org_notification_settings(web=True, email=True)
+        self._set_user_notification_settings("generic_message", web=False, email=False)
+        self._send_notification("generic_message")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_generic_type_org_disabled_user_enabled(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._set_user_notification_settings("generic_message", web=True, email=True)
+        self._send_notification("generic_message")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_generic_type_org_disabled_user_disabled(self):
+        self._set_org_notification_settings(web=False, email=False)
+        self._set_user_notification_settings("generic_message", web=False, email=False)
+        self._send_notification("generic_message")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_global_setting_web_disabled(self):
+        self._set_global_notification_settings(web=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+    def test_global_setting_email_disabled(self):
+        self._set_global_notification_settings(email=False)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(False)
+
+    def test_global_setting_propagation_sending_change(self):
+        self._set_global_notification_settings(web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+
+        self._set_global_notification_settings(web=False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
+
+        self._set_global_notification_settings(web=True, email=True)
+        self._send_notification("default")
+        self._assert_notification_created(True)
+        self._assert_email_sent(True)
+
+    def test_multi_org_notification_sending(self):
+        org_a = self.org
+        org_a_setting = OrganizationNotificationSettings.objects.get(organization=org_a)
+        org_a_setting.web = True
+        org_a_setting.save()
+        org_a_target = self.target
+        org_b = self._create_org(name="Org B")
+        org_b_setting = OrganizationNotificationSettings.objects.get(organization=org_b)
+        org_b_setting.web = False
+        org_b_setting.save()
+        org_b_target = self._create_org_user(organization=org_b, user=self.user)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+        with self.subTest("Web notifications enabled in Org A and disabled in Org B"):
+            notify.send(
+                sender=self.admin,
+                type="default",
+                target=org_a_target,
+                verb="To Org A",
+                email_subject="To Org A",
+            )
+            self._assert_notification_created(True, target=org_a_target)
+            self._assert_email_sent(True)
+
+            Notification.objects.all().delete()
+            mail.outbox.clear()
+            notify.send(
+                sender=self.admin,
+                type="default",
+                target=org_b_target,
+                verb="To Org B",
+                email_subject="To Org B",
+            )
+            self._assert_notification_created(False, target=org_b_target)
+            self._assert_email_sent(False)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+        with self.subTest(
+            "Global web notification disabled, Org A enabled, Org B disabled"
+        ):
+            global_setting = NotificationSetting.objects.get(
+                user=self.admin, type=None, organization=None
+            )
+            global_setting.web = False
+            global_setting.save()
+            notify.send(
+                sender=self.admin,
+                type="default",
+                target=org_a_target,
+                verb="To Org A",
+                email_subject="To Org A",
+            )
+            self._assert_notification_created(False, target=org_a_target)
+            self._assert_email_sent(False)
+
+        with self.subTest(
+            "Global web notification disabled, override specific notification"
+        ):
+            Notification.objects.all().delete()
+            mail.outbox.clear()
+            ns = NotificationSetting.objects.get(
+                user=self.admin, organization=org_b, type="default"
+            )
+            ns.web = True
+            ns.email = True
+            ns.save()
+            notify.send(
+                sender=self.admin,
+                type="default",
+                target=org_b_target,
+                verb="To Org B",
+                email_subject="To Org B",
+            )
+            self._assert_notification_created(True, target=org_b_target)
+            self._assert_email_sent(True)
 
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1543,6 +1543,7 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
         self.target = self._create_org_user(organization=self.org, user=self.user)
         Notification.objects.all().delete()
         mail.outbox.clear()
+        cache.delete(Notification.get_user_batched_notifications_cache_key(self.admin))
 
     def _set_org_notification_settings(self, web=None, email=None):
         org_setting = OrganizationNotificationSettings.objects.get(

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1793,6 +1793,7 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
                 user=self.admin, type=None, organization=None
             )
             global_setting.web = False
+            global_setting.full_clean()
             global_setting.save()
             notify.send(
                 sender=self.admin,

--- a/openwisp_notifications/tests/test_organization_setting.py
+++ b/openwisp_notifications/tests/test_organization_setting.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django.test import TransactionTestCase
 
 from openwisp_notifications.swapper import load_model, swapper_load_model
@@ -116,21 +114,3 @@ class TestOrganizationNotificationSettings(TestOrganizationMixin, TransactionTes
             org.notification_settings.pk,
             org_setting.pk,
         )
-
-    def test_updating_notification_setting_for_deleted_org(self):
-        org = self._get_org()
-        org_setting = org.notification_settings
-        self.assertEqual(org_setting.web, True)
-        self.assertEqual(org_setting.email, True)
-        org.delete()
-        self.assertEqual(
-            OrganizationNotificationSettings.objects.filter(
-                organization_id=org.pk
-            ).count(),
-            0,
-        )
-        with patch.object(NotificationSetting.objects, "update") as mocked_update:
-            with self.assertRaises(ValueError):
-                org_setting.web = False
-                org_setting.save()
-        mocked_update.assert_not_called()

--- a/openwisp_notifications/tests/test_organization_setting.py
+++ b/openwisp_notifications/tests/test_organization_setting.py
@@ -56,25 +56,6 @@ class TestOrganizationNotificationSettings(TestOrganizationMixin, TransactionTes
             self.assertEqual(org_setting.email, False)
             self.assertEqual(org_setting.web, False)
 
-    def test_org_setting_changes_user_preferences(self):
-        org = self._get_org()
-        org_setting = org.notification_settings
-        administrator = self._create_administrator(organizations=[org])
-
-        with self.subTest("Disabling web for org disabled all notifications for users"):
-            org_setting.web = False
-            org_setting.full_clean()
-            org_setting.save()
-            self.assertEqual(org_setting.email, False)
-            self.assertEqual(org_setting.web, False)
-            user_settings = NotificationSetting.objects.filter(
-                organization=org, user=administrator
-            )
-            self.assertEqual(user_settings.count(), len(NOTIFICATION_TYPES.keys()))
-            for setting in user_settings:
-                self.assertEqual(setting.web, False)
-                self.assertEqual(setting.email, False)
-
     def test_new_orguser_uses_org_setting_as_default(self):
         org1 = self._get_org()
         org1_setting = org1.notification_settings

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -171,11 +171,13 @@ class TestSelenium(
 
         with self.subTest("Network request fails"):
             self.open(unsubscribe_link)
-            self.web_driver.execute_script("""
+            self.web_driver.execute_script(
+                """
                 window.fetch = function() {
                     return Promise.reject(new Error('Simulated fetch failure'));
                 };
-            """)
+            """
+            )
             self.web_driver.find_element(By.ID, "toggle-btn").click()
             self.wait_for_visibility(By.ID, "error-msg")
             browser_logs = self.get_browser_logs()

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -253,7 +253,7 @@ class TestSelenium(
                 NotificationSetting.objects.get(
                     pk=input.get_attribute("data-pk")
                 ).email,
-                True,
+                None,
             )
 
     def test_empty_notification_preference_page(self):
@@ -272,6 +272,7 @@ class TestSelenium(
         )
 
     def test_notification_preference_resolution_with_org_and_user_override(self):
+        Organization.objects.all().delete()
         self.login()
         org = self._get_org()
         setting = NotificationSetting.objects.get(

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -1,7 +1,7 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import tag
 from django.urls import reverse
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
@@ -313,7 +313,7 @@ class TestSelenium(
                     lambda d: d.find_element(By.CLASS_NAME, "toast")
                 )
                 toast.click()
-            except TimeoutException:
+            except (TimeoutException, StaleElementReferenceException):
                 pass
 
         def _set_user_web(value: bool):

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -1,6 +1,7 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import tag
 from django.urls import reverse
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
@@ -273,7 +274,6 @@ class TestSelenium(
         )
 
     def test_notification_preference_resolution_with_org_and_user_override(self):
-        Organization.objects.all().delete()
         self.login()
         org = self._get_org()
         setting = NotificationSetting.objects.get(
@@ -314,7 +314,7 @@ class TestSelenium(
                     lambda d: d.find_element(By.CLASS_NAME, "toast")
                 )
                 toast.click()
-            except Exception:
+            except TimeoutException:
                 pass
 
         def _set_user_web(value: bool):

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -172,13 +172,11 @@ class TestSelenium(
 
         with self.subTest("Network request fails"):
             self.open(unsubscribe_link)
-            self.web_driver.execute_script(
-                """
+            self.web_driver.execute_script("""
                 window.fetch = function() {
                     return Promise.reject(new Error('Simulated fetch failure'));
                 };
-            """
-            )
+            """)
             self.web_driver.find_element(By.ID, "toggle-btn").click()
             self.wait_for_visibility(By.ID, "error-msg")
             browser_logs = self.get_browser_logs()

--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -2,7 +2,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import tag
 from django.urls import reverse
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from openwisp_notifications.signals import notify
 from openwisp_notifications.swapper import load_model, swapper_load_model
@@ -271,6 +271,112 @@ class TestSelenium(
             no_organizations_element.text,
             "No organizations available.",
         )
+
+    def test_notification_preference_resolution_with_org_and_user_override(self):
+        Organization.objects.all().delete()
+        self.login()
+        org = self._get_org()
+        setting = NotificationSetting.objects.get(
+            user=self.admin,
+            organization=org,
+            type="default",
+            web=None,
+            email=None,
+        )
+        self.open(reverse("notifications:notification_preference"))
+
+        def _expand_org():
+            self.find_element(By.CSS_SELECTOR, ".toggle-icon").click()
+
+        def _set_org_settings(web, email):
+            org.notification_settings.refresh_from_db()
+            org.notification_settings.web = web
+            org.notification_settings.email = email
+            org.notification_settings.save()
+
+        def _get_web_checkbox():
+            return self.find_element(
+                By.CSS_SELECTOR,
+                f'input[data-pk="{setting.pk}"][data-type="web"]',
+                wait_for="presence",
+            )
+
+        def _get_email_checkbox():
+            return self.find_element(
+                By.CSS_SELECTOR,
+                f'input[data-pk="{setting.pk}"][data-type="email"]',
+                wait_for="presence",
+            )
+
+        def _dismiss_toast_if_present():
+            try:
+                toast = WebDriverWait(self.web_driver, 1).until(
+                    lambda d: d.find_element(By.CLASS_NAME, "toast")
+                )
+                toast.click()
+            except Exception:
+                pass
+
+        def _set_user_web(value: bool):
+            cb = _get_web_checkbox()
+            if cb.is_selected() != value:
+                parent = cb.find_element(By.XPATH, "..")
+                _dismiss_toast_if_present()
+                parent.click()
+
+        def _set_user_email(value: bool):
+            cb = _get_email_checkbox()
+            if cb.is_selected() != value:
+                parent = cb.find_element(By.XPATH, "..")
+                _dismiss_toast_if_present()
+                parent.click()
+
+        def _verify_state(expected_web, expected_email):
+            self.web_driver.refresh()
+            self._wait_until_page_ready()
+            _expand_org()
+            self.assertEqual(_get_web_checkbox().is_selected(), expected_web)
+            self.assertEqual(_get_email_checkbox().is_selected(), expected_email)
+
+        with self.subTest("Org enabled + user None → enabled"):
+            _set_org_settings(web=True, email=True)
+            self.assertEqual(setting.web, None)
+            self.assertEqual(setting.email, None)
+            _verify_state(expected_web=True, expected_email=True)
+
+        with self.subTest("Org disabled + user None → disabled"):
+            _set_org_settings(web=False, email=False)
+            self.assertEqual(setting.web, None)
+            self.assertEqual(setting.email, None)
+            _verify_state(expected_web=False, expected_email=False)
+
+        with self.subTest("Org disabled + user override ON → enabled"):
+            _set_org_settings(web=False, email=False)
+            _set_user_web(True)
+            _set_user_email(True)
+            _verify_state(expected_web=True, expected_email=True)
+
+        with self.subTest("Org enabled + user override ON → enabled"):
+            _set_org_settings(web=True, email=True)
+            _set_user_web(True)
+            _set_user_email(True)
+            _verify_state(expected_web=True, expected_email=True)
+
+        with self.subTest("Org enabled + user override OFF → disabled"):
+            _set_org_settings(web=True, email=True)
+            _set_user_web(False)
+            _set_user_email(False)
+            _verify_state(expected_web=False, expected_email=False)
+
+        with self.subTest("Return to inherited state → DB None, UI ON"):
+            _set_org_settings(web=True, email=True)
+            _set_user_web(True)
+            _set_user_email(True)
+            _verify_state(expected_web=True, expected_email=True)
+
+            setting.refresh_from_db()
+            self.assertIsNone(setting.web)
+            self.assertIsNone(setting.email)
 
     def test_organization_admin_notification_settings(self):
         """Test the organization-settings.js functionality in Django admin"""

--- a/openwisp_notifications/utils.py
+++ b/openwisp_notifications/utils.py
@@ -69,7 +69,6 @@ def send_notification_email(
     notifications_count=0,
     user=None,
 ):
-
     extra_context = {}
     current_site = Site.objects.get_current()
     if isinstance(notifications, load_model("Notification")):
@@ -168,8 +167,14 @@ def get_user_email_preference(notification):
         # therefore send email anyway.
         return True
     try:
-        return notification.recipient.notificationsetting_set.get(
-            organization=target_org, type=notification.type
-        ).email_notification
+        return (
+            # Avoid an extra query when email_notification accesses
+            # organization.notification_settings.
+            notification.recipient.notificationsetting_set.select_related(
+                "organization__notification_settings"
+            )
+            .get(organization=target_org, type=notification.type)
+            .email_notification
+        )
     except ObjectDoesNotExist:
         return False


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #448

## Description of Changes
Fixed multiple bugs in notification preference resolution and sending logic.

Key changes:
- Introduced a three-tier resolution order for notification preferences: **user setting → org setting → type default**. Removed the old behavior where changing org-level settings would cascade down and overwrite user-level preferences stored in `NotificationSetting`.
- Added `normalize_settings()` on `AbstractNotificationSetting` to compute whether a user's setting matches the resolved default (storing `None` when it does, avoiding redundant DB rows).
- Updated `notify_handler` to consult organization-level web settings when determining which users to include for a given notification.
- Reworked `create_notification_settings` task to respect global notification preferences when provisioning settings for new organizations or org-users.
- Optimized the notification settings API view with `select_related` to reduce database queries.
