### PR TITLE
[fix] Create global notification settings for non-org admin staff users #453

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -335,38 +335,52 @@ def notification_setting_delete_org_user(instance, **kwargs):
 @receiver(pre_save, sender=User, dispatch_uid="superuser_demoted_notification_setting")
 def superuser_status_changed_notification_setting(instance, update_fields, **kwargs):
     """
-    If user is demoted from superuser status, then
-    remove notification settings for non-managed organizations.
-
-    If user is promoted to superuser, then
-    create notification settings for all organizations.
+    Handles modification of user notification settings when
+    privileges change. This works on either staff users or super users.
     """
-    if update_fields is not None and "is_superuser" not in update_fields:
-        # No-op if is_superuser field is not being updated.
-        # If update_fields is None, it means any field could be updated.
+    if update_fields is not None and not {"is_superuser", "is_staff"}.intersection(
+        update_fields
+    ):
+        # No-op if relevant privilege fields are not being updated.
         return
     try:
-        db_instance = User.objects.only("is_superuser").get(pk=instance.pk)
+        db_instance = User.objects.only("is_superuser", "is_staff").get(pk=instance.pk)
     except User.DoesNotExist:
         # User is being created
         return
-    # If user is demoted from superuser to non-superuser
-    if db_instance.is_superuser and not instance.is_superuser:
-        transaction.on_commit(
-            lambda: tasks.superuser_demoted_notification_setting.delay(instance.pk)
-        )
-    elif not db_instance.is_superuser and instance.is_superuser:
-        transaction.on_commit(
-            lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
-        )
+    was_privileged = db_instance.is_superuser or db_instance.is_staff
+    is_now_privileged = instance.is_superuser or instance.is_staff
+    # Transition Scenarios
+    gained_superuser = not db_instance.is_superuser and instance.is_superuser
+    gained_first_privilege = not was_privileged and is_now_privileged
+    lost_superuser = db_instance.is_superuser and not instance.is_superuser
+    lost_all_privileges = was_privileged and not is_now_privileged
+    # Attach transition flags to the instance to dispatch safely in post_save
+    # This bypasses eager Celery race conditions in testing environments
+    instance._lost_privileges = lost_superuser or lost_all_privileges
+    instance._gained_privileges = gained_superuser or gained_first_privilege
 
 
 @receiver(post_save, sender=User, dispatch_uid="create_superuser_notification_settings")
 def create_superuser_notification_settings(instance, created, **kwargs):
-    if created and instance.is_superuser:
+    """
+    Triggers initialization or modification of notification settings for privileged users.
+    Handles initial account creation as well as dynamic privilege level updates.
+    This works on either staff users or super users.
+    """
+    if created and (instance.is_superuser or instance.is_staff):
         transaction.on_commit(
             lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
         )
+    elif not created:
+        if getattr(instance, "_lost_privileges", False):
+            transaction.on_commit(
+                lambda: tasks.superuser_demoted_notification_setting.delay(instance.pk)
+            )
+        elif getattr(instance, "_gained_privileges", False):
+            transaction.on_commit(
+                lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
+            )
 
 
 @receiver(

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -352,13 +352,11 @@ def superuser_status_changed_notification_setting(instance, update_fields, **kwa
         return
     was_privileged = db_instance.is_superuser or db_instance.is_staff
     is_now_privileged = instance.is_superuser or instance.is_staff
-    # Transition Scenarios
     gained_superuser = not db_instance.is_superuser and instance.is_superuser
     gained_first_privilege = not was_privileged and is_now_privileged
     lost_superuser = db_instance.is_superuser and not instance.is_superuser
     lost_all_privileges = was_privileged and not is_now_privileged
-    # Attach transition flags to the instance to dispatch safely in post_save
-    # This bypasses eager Celery race conditions in testing environments
+    # Flags are read by the post_save handler to dispatch the matching task.
     instance._lost_privileges = lost_superuser or lost_all_privileges
     instance._gained_privileges = gained_superuser or gained_first_privilege
 

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -338,6 +338,8 @@ def superuser_status_changed_notification_setting(instance, update_fields, **kwa
     Handles modification of user notification settings when
     privileges change. This works on either staff users or super users.
     """
+    instance._lost_privileges = False
+    instance._gained_privileges = False
     if update_fields is not None and not {"is_superuser", "is_staff"}.intersection(
         update_fields
     ):
@@ -373,11 +375,15 @@ def create_superuser_notification_settings(instance, created, **kwargs):
             lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
         )
     elif not created:
-        if getattr(instance, "_lost_privileges", False):
+        lost_privileges = getattr(instance, "_lost_privileges", False)
+        gained_privileges = getattr(instance, "_gained_privileges", False)
+        instance._lost_privileges = False
+        instance._gained_privileges = False
+        if lost_privileges:
             transaction.on_commit(
                 lambda: tasks.superuser_demoted_notification_setting.delay(instance.pk)
             )
-        elif getattr(instance, "_gained_privileges", False):
+        elif gained_privileges:
             transaction.on_commit(
                 lambda: tasks.create_superuser_notification_settings.delay(instance.pk)
             )

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -156,7 +156,7 @@ def create_superuser_notification_settings(user_id):
             notification_types=types.NOTIFICATION_TYPES.keys(),
         )
     else:
-        # Creates global notification setting for the user
+        # Empty iterables create only the global setting row.
         create_notification_settings(user=user, organizations=[], notification_types=[])
 
 

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -103,6 +103,9 @@ def create_notification_settings(user, organizations, notification_types):
     global_setting, _ = NotificationSetting.objects.get_or_create(
         user=user, organization=None, type=None, defaults={"email": True, "web": True}
     )
+    if global_setting.deleted:
+        global_setting.deleted = False
+        global_setting.save(update_fields=["deleted"])
 
     for type in notification_types:
         for org in organizations:
@@ -155,7 +158,7 @@ def create_superuser_notification_settings(user_id):
             organizations=Organization.objects.all(),
             notification_types=types.NOTIFICATION_TYPES.keys(),
         )
-    else:
+    elif user.is_staff:
         # Empty iterables create only the global setting row.
         create_notification_settings(user=user, organizations=[], notification_types=[])
 

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -213,9 +213,10 @@ def ns_register_unregister_notification_type(
 
     if delete_unregistered:
         # Delete all notification settings for unregistered notification types
-        NotificationSetting.objects.exclude(type__in=notification_types).update(
-            deleted=True
-        )
+        # exclude(type=None) protects the global settings row from deletion
+        NotificationSetting.objects.exclude(type__in=notification_types).exclude(
+            type=None
+        ).update(deleted=True)
         # Delete notifications related to unregister notification types
         Notification.objects.exclude(type__in=notification_types).delete()
 

--- a/openwisp_notifications/tasks.py
+++ b/openwisp_notifications/tasks.py
@@ -144,27 +144,36 @@ def create_notification_settings(user, organizations, notification_types):
 @shared_task(base=OpenwispCeleryTask)
 def create_superuser_notification_settings(user_id):
     """
-    Adds notification setting for all notification types and organizations.
+    Adds notification settings for privileged users.
+    Creates a global row for staff and a full association grid for superusers.
+    This works on either staff users or super users.
     """
     user = User.objects.get(pk=user_id)
-    # Create notification settings for superuser
-    create_notification_settings(
-        user=user,
-        organizations=Organization.objects.all(),
-        notification_types=types.NOTIFICATION_TYPES.keys(),
-    )
+    if user.is_superuser:
+        create_notification_settings(
+            user=user,
+            organizations=Organization.objects.all(),
+            notification_types=types.NOTIFICATION_TYPES.keys(),
+        )
+    else:
+        # Creates global notification setting for the user
+        create_notification_settings(user=user, organizations=[], notification_types=[])
 
 
 @shared_task(base=OpenwispCeleryTask)
 def superuser_demoted_notification_setting(user_id):
     """
     Flags NotificationSettings as deleted for non-managed organizations
-    when a superuser is demoted to a non-superuser.
+    when a superuser is demoted to a non-superuser, or privileges are removed.
     """
     user = User.objects.get(pk=user_id)
-    NotificationSetting.objects.filter(user_id=user_id).exclude(
+    qs = NotificationSetting.objects.filter(user_id=user_id).exclude(
         organization__in=user.organizations_managed
-    ).update(deleted=True)
+    )
+    # Do not delete global setting if user is staff or manages at least one organization
+    if user.is_staff or user.organizations_managed:
+        qs = qs.exclude(organization=None)
+    qs.update(deleted=True)
 
 
 @shared_task(base=OpenwispCeleryTask)
@@ -184,6 +193,12 @@ def ns_register_unregister_notification_type(
     # Create notification settings for superusers
     for user in User.objects.filter(is_superuser=True).iterator():
         create_notification_settings(user, organizations, notification_types)
+
+    # Create notification settings for staff users
+    # Skip during single-type registration since global rows are independent of types
+    if notification_type is None:
+        for user in User.objects.filter(is_staff=True, is_superuser=False).iterator():
+            create_notification_settings(user, [], [])
 
     # Create notification settings for organization admin
     for org_user in OrganizationUser.objects.select_related(
@@ -212,9 +227,13 @@ def update_org_user_notificationsetting(org_user_id, user_id, org_id, is_org_adm
     if not user.is_superuser:
         # The following query covers conditions for change in admin status
         # and organization field of related OrganizationUser objects
-        NotificationSetting.objects.filter(user=user).exclude(
+        qs = NotificationSetting.objects.filter(user=user).exclude(
             organization_id__in=user.organizations_managed
-        ).update(deleted=True)
+        )
+        # Do not delete global setting if user is staff or manages at least one organization
+        if user.is_staff or user.organizations_managed:
+            qs = qs.exclude(organization=None)
+        qs.update(deleted=True)
 
     if not is_org_admin:
         return

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -131,7 +131,8 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(ns_queryset.filter(type="default", deleted=True).count(), 3)
 
         # Notification Settings for "test" type are created
-        queryset = NotificationSetting.objects.filter(deleted=False)
+        # We exclude the global row (type=None) to correctly count only typed settings
+        queryset = NotificationSetting.objects.filter(deleted=False).exclude(type=None)
         notification_types_count = len(NOTIFICATION_CHOICES)
         self.assertEqual(queryset.count(), 3 * notification_types_count)
         self.assertEqual(
@@ -141,16 +142,16 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             queryset.filter(user=org_user.user).count(), 1 * notification_types_count
         )
 
-        # Check Global Notification Setting is created
+        # Check Global Notification Setting is created and not deleted
         self.assertEqual(
             NotificationSetting.objects.filter(
-                user=admin, type=None, organization=None
+                user=admin, type=None, organization=None, deleted=False
             ).count(),
             1,
         )
         self.assertEqual(
             NotificationSetting.objects.filter(
-                user=org_user.user, type=None, organization=None
+                user=org_user.user, type=None, organization=None, deleted=False
             ).count(),
             1,
         )

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -665,9 +665,14 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(notification_setting.web_notification, False)
 
     def test_staff_user_created(self):
-        self._create_user(username="staff", email="staff@example.com", is_staff=True)
+        user = self._create_user(
+            username="staff", email="staff@example.com", is_staff=True
+        )
         self.assertEqual(
-            NotificationSetting.objects.filter(organization=None, type=None).count(), 1
+            NotificationSetting.objects.filter(
+                user=user, organization=None, type=None, deleted=False
+            ).count(),
+            1,
         )
 
     def test_user_promoted_to_staff(self):
@@ -677,7 +682,7 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         user.save()
         self.assertEqual(
             NotificationSetting.objects.filter(
-                user=user, organization=None, type=None
+                user=user, organization=None, type=None, deleted=False
             ).count(),
             1,
         )

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -697,6 +697,38 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             1,
         )
 
+    def test_create_superuser_notification_settings_skips_regular_user(self):
+        user = self._create_user(
+            username="regular_task", email="regular_task@example.com"
+        )
+        create_superuser_notification_settings.delay(user.pk)
+        self.assertFalse(
+            NotificationSetting.objects.filter(user=user).exists(),
+            "Regular users must not get notification settings from this task.",
+        )
+
+    def test_staff_repromoted_reactivates_global_preference(self):
+        user = self._create_user(
+            username="staff_repromote",
+            email="staff_repromote@example.com",
+            is_staff=True,
+        )
+        global_ns = NotificationSetting.objects.get(user=user, organization=None)
+        self.assertFalse(global_ns.deleted)
+
+        user.is_staff = False
+        user.save()
+        global_ns.refresh_from_db()
+        self.assertTrue(global_ns.deleted)
+
+        user.is_staff = True
+        user.save()
+        global_ns.refresh_from_db()
+        self.assertFalse(
+            global_ns.deleted,
+            "Re-promoting a staff user must reactivate the global setting.",
+        )
+
     def test_staff_joins_org_retains_global_preference(self):
         """
         Ensure the global notification setting is preserved when a staff user

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -340,6 +340,46 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             admin.save()
             created_mock.assert_called_once()
 
+    @patch.object(superuser_demoted_notification_setting, "delay")
+    @patch.object(create_superuser_notification_settings, "delay")
+    def test_privilege_flags_do_not_leak_to_unrelated_saves(
+        self, created_mock, demoted_mock
+    ):
+        with self.subTest("gained privileges"):
+            user = self._create_user(
+                username="gain_privilege", email="gain_privilege@example.com"
+            )
+            user.is_staff = True
+            user.save()
+            created_mock.assert_called_once()
+            demoted_mock.assert_not_called()
+
+            created_mock.reset_mock()
+            user.username = "gain_privilege_updated"
+            user.save(update_fields=["username"])
+            created_mock.assert_not_called()
+            demoted_mock.assert_not_called()
+
+        created_mock.reset_mock()
+        demoted_mock.reset_mock()
+        with self.subTest("lost privileges"):
+            user = self._create_user(
+                username="lose_privilege",
+                email="lose_privilege@example.com",
+                is_staff=True,
+            )
+            created_mock.reset_mock()
+            user.is_staff = False
+            user.save()
+            demoted_mock.assert_called_once()
+            created_mock.assert_not_called()
+
+            demoted_mock.reset_mock()
+            user.username = "lose_privilege_updated"
+            user.save(update_fields=["username"])
+            created_mock.assert_not_called()
+            demoted_mock.assert_not_called()
+
     def test_global_notification_setting_update(self):
         admin = self._get_admin()
         org = self._get_org("default")

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -307,8 +307,11 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
     @patch.object(create_superuser_notification_settings, "delay")
     def test_task_not_called_on_user_login(self, created_mock, demoted_mock):
         admin = self._create_admin()
+        # Called once for the superuser
+        self.assertEqual(created_mock.call_count, 1)
         org_user = self._create_staff_org_admin()
-        created_mock.assert_called_once()
+        # Called once again for the staff org admin user
+        self.assertEqual(created_mock.call_count, 2)
 
         created_mock.reset_mock()
         with self.subTest("Test task not called if superuser status is unchanged"):
@@ -628,3 +631,138 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         notification_setting.refresh_from_db()
         self.assertEqual(notification_setting.web, False)
         self.assertEqual(notification_setting.web_notification, False)
+
+    def test_staff_user_created(self):
+        """
+        Verify staff users receive global setting row on creation.
+        """
+        self._create_user(username="staff", email="staff@example.com", is_staff=True)
+        self.assertEqual(
+            NotificationSetting.objects.filter(organization=None, type=None).count(), 1
+        )
+
+    def test_user_promoted_to_staff(self):
+        """
+        Verify basic users get populated with global preference on staff promotion.
+        """
+        user = self._create_user(username="promote_staff", email="staff@example.com")
+        self.assertEqual(NotificationSetting.objects.count(), 0)
+
+        user.is_staff = True
+        user.save()
+        self.assertEqual(
+            NotificationSetting.objects.filter(
+                user=user, organization=None, type=None
+            ).count(),
+            1,
+        )
+
+    def test_staff_joins_org_retains_global_preference(self):
+        """
+        Ensure the global notification setting is preserved when a staff user
+        joins an organization (both as admin and regular member).
+        """
+        user = self._create_user(username="staff_org", is_staff=True)
+        org = self._get_org()
+        global_ns = NotificationSetting.objects.get(user=user, organization=None)
+        self.assertFalse(global_ns.deleted)
+
+        # Case A: Join org as regular member (is_admin=False)
+        org_user = OrganizationUser.objects.create(
+            user=user, organization=org, is_admin=False
+        )
+        global_ns.refresh_from_db()
+        self.assertFalse(
+            global_ns.deleted,
+            "Global setting was wiped when joining org as non-admin",
+        )
+
+        # Case B: Join org as admin (is_admin=True)
+        org_user.is_admin = True
+        org_user.save()
+        global_ns.refresh_from_db()
+        self.assertFalse(
+            global_ns.deleted, "Global setting was wiped when promoted to admin"
+        )
+
+    def test_superuser_and_staff_demoted_to_staff_only(self):
+        """
+        Verify demoting a Superuser+Staff to Staff-only preserves the
+        global setting but prunes per-organization records.
+        """
+        user = self._create_user(username="both_priv", is_superuser=True, is_staff=True)
+        # Superuser already has settings generated for ALL orgs automatically.
+        # Assert global row and organization rows exist initially.
+        self.assertTrue(
+            NotificationSetting.objects.filter(user=user, deleted=False).count() > 1
+        )
+
+        # Demote superuser status
+        user.is_superuser = False
+        user.save()
+        # Global row remains alive
+        global_ns = NotificationSetting.objects.get(user=user, organization=None)
+        self.assertFalse(
+            global_ns.deleted, "Global setting was deleted on superuser demotion"
+        )
+        # All organization rows are soft-deleted (user manages 0 orgs)
+        self.assertFalse(
+            NotificationSetting.objects.filter(user=user, deleted=False)
+            .exclude(organization=None)
+            .exists(),
+            "Org settings were not pruned on superuser demotion",
+        )
+
+    def test_staff_demoted_to_regular_user(self):
+        """
+        Verify that removing staff privilege from a basic staff user
+        who manages no orgs deletes their global notification setting.
+        """
+        user = self._create_user(username="staff_demote", is_staff=True)
+        global_ns = NotificationSetting.objects.get(user=user, organization=None)
+        self.assertFalse(global_ns.deleted)
+
+        # Demote from staff to normal user
+        user.is_staff = False
+        user.save()
+        global_ns.refresh_from_db()
+        self.assertTrue(
+            global_ns.deleted,
+            "Global setting was not deleted upon total privilege loss",
+        )
+
+    def test_staff_promoted_to_superuser(self):
+        """
+        Verify that promoting a staff user to superuser creates the full
+        association grid of settings for all organizations.
+        """
+        user = self._create_user(username="staff_to_super", is_staff=True)
+        self.assertEqual(NotificationSetting.objects.filter(user=user).count(), 1)
+
+        user.is_superuser = True
+        user.save()
+
+        self.assertTrue(NotificationSetting.objects.filter(user=user).count() > 1)
+
+    def test_superuser_and_staff_demoted_to_regular_user(self):
+        """
+        Verify demoting a Superuser+Staff to a regular user removes both
+        the organization-specific settings and the global setting.
+        """
+        user = self._create_user(
+            username="both_to_none", is_superuser=True, is_staff=True
+        )
+        self.assertTrue(
+            NotificationSetting.objects.filter(user=user, deleted=False).count() > 1
+        )
+
+        user.is_superuser = False
+        user.is_staff = False
+        user.save()
+
+        self.assertEqual(
+            NotificationSetting.objects.filter(user=user, deleted=False).count(), 0
+        )
+        self.assertTrue(
+            NotificationSetting.objects.filter(user=user, deleted=True).count() > 0
+        )

--- a/openwisp_notifications/tests/test_notification_setting.py
+++ b/openwisp_notifications/tests/test_notification_setting.py
@@ -312,30 +312,25 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         org_user = self._create_staff_org_admin()
         # Called once again for the staff org admin user
         self.assertEqual(created_mock.call_count, 2)
-
         created_mock.reset_mock()
         with self.subTest("Test task not called if superuser status is unchanged"):
             admin.username = "new_admin"
             admin.save()
             created_mock.assert_not_called()
             demoted_mock.assert_not_called()
-
         with self.subTest("Test task not called when superuser logs in"):
             self.client.force_login(admin)
             created_mock.assert_not_called()
             demoted_mock.assert_not_called()
-
         with self.subTest("Test task not called when org user logs in"):
             self.client.force_login(org_user.user)
             created_mock.assert_not_called()
             demoted_mock.assert_not_called()
-
         with self.subTest("Test task called when superuser status changed"):
             admin.is_superuser = False
             admin.save()
             demoted_mock.assert_called_once()
             created_mock.assert_not_called()
-
             admin.is_superuser = True
             admin.save()
             created_mock.assert_called_once()
@@ -353,13 +348,11 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             user.save()
             created_mock.assert_called_once()
             demoted_mock.assert_not_called()
-
             created_mock.reset_mock()
             user.username = "gain_privilege_updated"
             user.save(update_fields=["username"])
             created_mock.assert_not_called()
             demoted_mock.assert_not_called()
-
         created_mock.reset_mock()
         demoted_mock.reset_mock()
         with self.subTest("lost privileges"):
@@ -373,7 +366,6 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             user.save()
             demoted_mock.assert_called_once()
             created_mock.assert_not_called()
-
             demoted_mock.reset_mock()
             user.username = "lose_privilege_updated"
             user.save(update_fields=["username"])
@@ -673,21 +665,14 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         self.assertEqual(notification_setting.web_notification, False)
 
     def test_staff_user_created(self):
-        """
-        Verify staff users receive global setting row on creation.
-        """
         self._create_user(username="staff", email="staff@example.com", is_staff=True)
         self.assertEqual(
             NotificationSetting.objects.filter(organization=None, type=None).count(), 1
         )
 
     def test_user_promoted_to_staff(self):
-        """
-        Verify basic users get populated with global preference on staff promotion.
-        """
         user = self._create_user(username="promote_staff", email="staff@example.com")
         self.assertEqual(NotificationSetting.objects.count(), 0)
-
         user.is_staff = True
         user.save()
         self.assertEqual(
@@ -715,12 +700,10 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
         global_ns = NotificationSetting.objects.get(user=user, organization=None)
         self.assertFalse(global_ns.deleted)
-
         user.is_staff = False
         user.save()
         global_ns.refresh_from_db()
         self.assertTrue(global_ns.deleted)
-
         user.is_staff = True
         user.save()
         global_ns.refresh_from_db()
@@ -730,16 +713,10 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
 
     def test_staff_joins_org_retains_global_preference(self):
-        """
-        Ensure the global notification setting is preserved when a staff user
-        joins an organization (both as admin and regular member).
-        """
         user = self._create_user(username="staff_org", is_staff=True)
         org = self._get_org()
         global_ns = NotificationSetting.objects.get(user=user, organization=None)
         self.assertFalse(global_ns.deleted)
-
-        # Case A: Join org as regular member (is_admin=False)
         org_user = OrganizationUser.objects.create(
             user=user, organization=org, is_admin=False
         )
@@ -748,8 +725,6 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
             global_ns.deleted,
             "Global setting was wiped when joining org as non-admin",
         )
-
-        # Case B: Join org as admin (is_admin=True)
         org_user.is_admin = True
         org_user.save()
         global_ns.refresh_from_db()
@@ -758,26 +733,16 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
 
     def test_superuser_and_staff_demoted_to_staff_only(self):
-        """
-        Verify demoting a Superuser+Staff to Staff-only preserves the
-        global setting but prunes per-organization records.
-        """
         user = self._create_user(username="both_priv", is_superuser=True, is_staff=True)
-        # Superuser already has settings generated for ALL orgs automatically.
-        # Assert global row and organization rows exist initially.
         self.assertTrue(
             NotificationSetting.objects.filter(user=user, deleted=False).count() > 1
         )
-
-        # Demote superuser status
         user.is_superuser = False
         user.save()
-        # Global row remains alive
         global_ns = NotificationSetting.objects.get(user=user, organization=None)
         self.assertFalse(
             global_ns.deleted, "Global setting was deleted on superuser demotion"
         )
-        # All organization rows are soft-deleted (user manages 0 orgs)
         self.assertFalse(
             NotificationSetting.objects.filter(user=user, deleted=False)
             .exclude(organization=None)
@@ -786,15 +751,9 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
 
     def test_staff_demoted_to_regular_user(self):
-        """
-        Verify that removing staff privilege from a basic staff user
-        who manages no orgs deletes their global notification setting.
-        """
         user = self._create_user(username="staff_demote", is_staff=True)
         global_ns = NotificationSetting.objects.get(user=user, organization=None)
         self.assertFalse(global_ns.deleted)
-
-        # Demote from staff to normal user
         user.is_staff = False
         user.save()
         global_ns.refresh_from_db()
@@ -804,37 +763,8 @@ class TestNotificationSetting(TestOrganizationMixin, TransactionTestCase):
         )
 
     def test_staff_promoted_to_superuser(self):
-        """
-        Verify that promoting a staff user to superuser creates the full
-        association grid of settings for all organizations.
-        """
         user = self._create_user(username="staff_to_super", is_staff=True)
         self.assertEqual(NotificationSetting.objects.filter(user=user).count(), 1)
-
         user.is_superuser = True
         user.save()
-
         self.assertTrue(NotificationSetting.objects.filter(user=user).count() > 1)
-
-    def test_superuser_and_staff_demoted_to_regular_user(self):
-        """
-        Verify demoting a Superuser+Staff to a regular user removes both
-        the organization-specific settings and the global setting.
-        """
-        user = self._create_user(
-            username="both_to_none", is_superuser=True, is_staff=True
-        )
-        self.assertTrue(
-            NotificationSetting.objects.filter(user=user, deleted=False).count() > 1
-        )
-
-        user.is_superuser = False
-        user.is_staff = False
-        user.save()
-
-        self.assertEqual(
-            NotificationSetting.objects.filter(user=user, deleted=False).count(), 0
-        )
-        self.assertTrue(
-            NotificationSetting.objects.filter(user=user, deleted=True).count() > 0
-        )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #453.

## Description of Changes

Standard staff users (those who are not organization administrators) were
created without a global notification setting, leaving them with an empty
notification preferences UI. This PR ensures the global setting is created
and preserved for staff users across the relevant user and organization
lifecycle events.

### Handlers (`handlers.py`)

- The pre_save handler now reacts to changes in `is_staff` as well as
  `is_superuser`, and records transition flags on the user instance.
- The post_save handler reads those flags and dispatches the matching
  task on creation, privilege gain, or privilege loss, so staff users get
  a global setting on creation or promotion.

### Tasks (`tasks.py`)

- `create_superuser_notification_settings` now creates only the global row
  for staff users and is a no-op for regular users.
- `create_notification_settings` reactivates a soft-deleted global row when
  the user regains privilege, so re-promotions restore the UI.
- `superuser_demoted_notification_setting` and
  `update_org_user_notificationsetting` no longer wipe the global row when
  the user remains staff or still manages at least one organization. This
  also fixes a related bug where `exclude(organization_id__in=[...])` did
  not exclude rows where `organization_id IS NULL`, causing the global row
  to be soft-deleted when a staff user joined an organization.
- `ns_register_unregister_notification_type` ensures the global row exists
  for staff users on full registration. The staff loop is skipped on
  single-type registration since the global row is type-independent.

Public task and handler names were preserved for backward compatibility;
docstrings now note that they cover both staff users and superusers.

### Tests (`test_notification_setting.py`)

New regression tests cover:

- Staff user creation and promotion produce an active global setting.
- All demotion paths: staff to regular, superuser+staff to staff-only,
  and full privilege loss.
- Re-promotion reactivates a soft-deleted global setting.
- Joining an organization as a non-admin and as an admin both preserve a
  staff user's global setting.
- The pre_save transition flags do not leak across unrelated user saves.
- The task is a no-op when invoked for a regular user.

## Screenshot

N/A, backend-only change covered by tests.
