### PR TITLE
[fix] Filtered out soft-deleted notification settings in user preferences API #452

### DIFF
--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -132,7 +132,7 @@ class BaseNotificationSettingView(GenericAPIView):
                 Q(organization__is_active=False)
                 | Q(type__in=app_settings.DISALLOW_PREFERENCES_CHANGE_TYPE)
             )
-            .filter(user_id=user_id)
+            .filter(user_id=user_id, deleted=False)
             .select_related("organization__notification_settings")
         )
 

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1202,7 +1202,9 @@ class TestNotificationApi(
     def test_preferences_api_excludes_removed_org_user_settings(self):
         org = self._get_org()
         owner_user = self._get_user()
-        OrganizationUser.objects.create(user=owner_user, organization=org, is_admin=True)
+        OrganizationUser.objects.create(
+            user=owner_user, organization=org, is_admin=True
+        )
         non_owner = self._create_user(username="non_owner", email="non_owner@test.com")
         org_user = OrganizationUser.objects.create(
             user=non_owner, organization=org, is_admin=True

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -26,7 +26,6 @@ NotificationSetting = load_model("NotificationSetting")
 IgnoreObjectNotification = load_model("IgnoreObjectNotification")
 
 Organization = swapper_load_model("openwisp_users", "Organization")
-OrganizationUser = swapper_load_model("openwisp_users", "OrganizationUser")
 
 
 class TestNotificationMixin:
@@ -1201,49 +1200,23 @@ class TestNotificationApi(
     @mock_notification_types
     def test_preferences_api_excludes_removed_org_user_settings(self):
         org = self._get_org()
-        owner_user = self._get_user()
-        OrganizationUser.objects.create(
-            user=owner_user, organization=org, is_admin=True
-        )
-        non_owner = self._create_user(username="non_owner", email="non_owner@test.com")
-        org_user = OrganizationUser.objects.create(
-            user=non_owner, organization=org, is_admin=True
-        )
+        self._create_org_user(user=self._get_user(), organization=org, is_admin=True)
+        user = self._create_user(username="non_owner", email="non_owner@test.com")
+        org_user = self._create_org_user(user=user, organization=org, is_admin=True)
+        self.client.force_login(user)
         url = reverse(
             "notifications:user_notification_setting_list",
-            kwargs={"user_id": str(non_owner.id)},
+            kwargs={"user_id": str(user.id)},
         )
-        with self.subTest(
-            "superuser: preferences visible before OrganizationUser deletion"
-        ):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            org_ids = [obj["organization"] for obj in response.data["results"]]
-            self.assertIn(org.id, org_ids)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        org_ids = {obj["organization"] for obj in response.data["results"]}
+        self.assertIn(org.id, org_ids)
         org_user.delete()
-        with self.subTest(
-            "superuser: preferences hidden after OrganizationUser deletion"
-        ):
-            self.client.force_login(self.admin)
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            org_ids = [obj["organization"] for obj in response.data["results"]]
-            self.assertNotIn(org.id, org_ids)
-        org_user = OrganizationUser.objects.create(
-            user=non_owner, organization=org, is_admin=True
-        )
-        self.client.force_login(non_owner)
-        with self.subTest("user: preferences visible before OrganizationUser deletion"):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            org_ids = [obj["organization"] for obj in response.data["results"]]
-            self.assertIn(org.id, org_ids)
-        org_user.delete()
-        with self.subTest("user: preferences hidden after OrganizationUser deletion"):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            org_ids = [obj["organization"] for obj in response.data["results"]]
-            self.assertNotIn(org.id, org_ids)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        org_ids = {obj["organization"] for obj in response.data["results"]}
+        self.assertNotIn(org.id, org_ids)
 
     def test_organization_setting_superuser_access(self):
         """Test superuser can retrieve and update organization notification settings"""

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1198,6 +1198,31 @@ class TestNotificationApi(
         for obj in response.data["results"]:
             self.assertNotEqual(obj["organization_id"], str(inactive_org.id))
 
+    @mock_notification_types
+    def test_preferences_api_excludes_removed_org_user_settings(self):
+        org = self._get_org()
+        owner_user = self._get_user()
+        OrganizationUser.objects.create(user=owner_user, organization=org, is_admin=True)
+        non_owner = self._create_user(username="non_owner", email="non_owner@test.com")
+        org_user = OrganizationUser.objects.create(
+            user=non_owner, organization=org, is_admin=True
+        )
+        url = reverse(
+            "notifications:user_notification_setting_list",
+            kwargs={"user_id": str(non_owner.id)},
+        )
+        with self.subTest("Preferences visible before OrganizationUser deletion"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            org_ids = [obj["organization"] for obj in response.data["results"]]
+            self.assertIn(org.id, org_ids)
+        org_user.delete()
+        with self.subTest("Preferences hidden after OrganizationUser deletion"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            org_ids = [obj["organization"] for obj in response.data["results"]]
+            self.assertNotIn(org.id, org_ids)
+
     def test_organization_setting_superuser_access(self):
         """Test superuser can retrieve and update organization notification settings"""
         # Create superuser

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -1213,13 +1213,33 @@ class TestNotificationApi(
             "notifications:user_notification_setting_list",
             kwargs={"user_id": str(non_owner.id)},
         )
-        with self.subTest("Preferences visible before OrganizationUser deletion"):
+        with self.subTest(
+            "superuser: preferences visible before OrganizationUser deletion"
+        ):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             org_ids = [obj["organization"] for obj in response.data["results"]]
             self.assertIn(org.id, org_ids)
         org_user.delete()
-        with self.subTest("Preferences hidden after OrganizationUser deletion"):
+        with self.subTest(
+            "superuser: preferences hidden after OrganizationUser deletion"
+        ):
+            self.client.force_login(self.admin)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            org_ids = [obj["organization"] for obj in response.data["results"]]
+            self.assertNotIn(org.id, org_ids)
+        org_user = OrganizationUser.objects.create(
+            user=non_owner, organization=org, is_admin=True
+        )
+        self.client.force_login(non_owner)
+        with self.subTest("user: preferences visible before OrganizationUser deletion"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            org_ids = [obj["organization"] for obj in response.data["results"]]
+            self.assertIn(org.id, org_ids)
+        org_user.delete()
+        with self.subTest("user: preferences hidden after OrganizationUser deletion"):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             org_ids = [obj["organization"] for obj in response.data["results"]]


### PR DESCRIPTION
## Checklist

 I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
 I have manually tested the changes proposed in this pull request.
 I have written new test cases for new code and/or updated existing tests for changes to existing code.
 I have updated the documentation.

Closes https://github.com/openwisp/openwisp-notifications/issues/452

## Description of Changes

I figured out the issue. The /notifications/preferences/ page uses JavaScript to fetch data from the /api/v1/notifications/user/{id}/user-setting/ API. When an OrganizationUser is deleted, their notification settings are correctly marked as deleted=True in the database. However, the API wasn't filtering those out—it was still returning the deleted settings. That is why they were still showing up on the frontend.

## Technical Changes

In api/views.py, I updated BaseNotificationSettingView.get_queryset() by adding .filter(user_id=user_id, deleted=False). This ensures the API only returns active settings.
I added a test in test_api.py that exactly reproduces the bug's steps:
Created an organization admin.
Confirmed their preferences.
Deleted the organization user.
Called the preferences API again and asserted that the settings for the deleted organization no longer appear in the response.

## images
<img width="953" height="233" alt="before" src="https://github.com/user-attachments/assets/d4f94437-0718-42ec-b914-b4ecc0b27c4b" />
before 
<img width="940" height="272" alt="after 1" src="https://github.com/user-attachments/assets/9654ab2d-ff02-4522-878a-29e4769f2838" />

<img width="940" height="272" alt="after" src="https://github.com/user-attachments/assets/d9b0c38c-9b31-4c53-ae62-043ed03d51a0" />
after
 