### PR TITLE
[fix] Restrict notification preferences page to admins #462

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ The repository is a single Python package, not a monorepo.
 - Use `.github/workflows/build.yml` as the authoritative compatibility matrix for supported Python and Django versions.
 - Preserve swappable model support and integration with `openwisp-users` organizations and memberships.
 - Be careful with notification preference inheritance, global notification settings, soft-deleted `NotificationSetting` rows, and user/organization permission boundaries.
+- Mark user-facing strings as translatable with Django i18n helpers, typically `gettext_lazy` imported as `_`.
 - Add or update tests for behavior changes.
 - For bug fixes, prefer the red/green workflow: write or update the regression test first, run it against the unfixed code and confirm the failure message is clear, then apply the fix and rerun the targeted test plus the relevant module.
 

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -9,6 +9,7 @@ from celery.exceptions import OperationalError
 from django.apps.registry import apps
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages import get_messages
 from django.core import mail
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -1502,7 +1503,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
 
     def test_notification_preference_page(self):
         preference_page = "notifications:user_notification_preference"
-        tester = self._create_user(username="tester")
+        tester = self._create_user(username="tester", is_staff=True)
 
         with self.subTest("Test user is not authenticated"):
             response = self.client.get(reverse(preference_page, args=(self.admin.pk,)))
@@ -1531,6 +1532,27 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         with self.subTest("Test invalid user ID"):
             response = self.client.get(reverse(preference_page, args=(uuid4(),)))
             self.assertEqual(response.status_code, 404)
+
+    def test_notification_preference_page_regular_user_redirects_to_admin(self):
+        user = self._create_user(username="regular_preference_user")
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("notifications:user_notification_preference", args=(user.pk,))
+        )
+        self.assertEqual(
+            response.status_code,
+            302,
+            "Notification preferences for regular users must redirect to the admin index.",
+        )
+        self.assertRedirects(
+            response, reverse("admin:index"), fetch_redirect_response=False
+        )
+        self.assertEqual(
+            [str(message) for message in get_messages(response.wsgi_request)],
+            [
+                "Notification preferences are available only for staff users or superusers."
+            ],
+        )
 
 
 class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1554,6 +1554,27 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             ],
         )
 
+    def test_notification_preference_page_cross_user_access_denied_before_lookup(self):
+        user = self._create_user(
+            username="cross_user_requester", email="cross_user_requester@example.com"
+        )
+        target = self._create_user(
+            username="cross_user_target",
+            email="cross_user_target@example.com",
+        )
+        self.client.force_login(user)
+        for target_pk in [target.pk, uuid4()]:
+            with self.subTest(target_pk=target_pk):
+                url = reverse(
+                    "notifications:user_notification_preference", args=(target_pk,)
+                )
+                response = self.client.get(url)
+                self.assertEqual(
+                    response.status_code,
+                    403,
+                    "Cross-user preference access must be denied before resolving the target user.",
+                )
+
 
 class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
     app_label = "openwisp_notifications"

--- a/openwisp_notifications/views.py
+++ b/openwisp_notifications/views.py
@@ -82,6 +82,14 @@ class NotificationPreferenceView(LoginRequiredMixin, UserPassesTestMixin, Templa
         return self.user
 
     def dispatch(self, request, *args, **kwargs):
+        user_id = kwargs.get("pk")
+        if (
+            request.user.is_authenticated
+            and user_id
+            and not request.user.is_superuser
+            and str(request.user.pk) != str(user_id)
+        ):
+            return self.handle_no_permission()
         if request.user.is_authenticated:
             user = self._get_user()
             if not user.is_staff and not user.is_superuser:

--- a/openwisp_notifications/views.py
+++ b/openwisp_notifications/views.py
@@ -68,22 +68,41 @@ class NotificationPreferenceView(LoginRequiredMixin, UserPassesTestMixin, Templa
     template_name = "openwisp_notifications/preferences.html"
     login_url = reverse_lazy("admin:login")
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
+    def _get_user(self):
+        if hasattr(self, "user"):
+            return self.user
         user_id = self.kwargs.get("pk")
-        context["title"] = _("Notification Preferences")
-
         if user_id:
             try:
-                user = User.objects.get(pk=user_id)
-                # Only admin should access other users preferences
-                context["username"] = user.username
-                context["title"] += f" ({user.username})"
+                self.user = User.objects.get(pk=user_id)
             except User.DoesNotExist:
-                raise Http404("User does not exist")
+                raise Http404(_("User does not exist"))
         else:
-            user = self.request.user
+            self.user = self.request.user
+        return self.user
 
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            user = self._get_user()
+            if not user.is_staff and not user.is_superuser:
+                messages.error(
+                    request,
+                    _(
+                        "Notification preferences are available only for staff users "
+                        "or superusers."
+                    ),
+                )
+                return redirect(reverse("admin:index"))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = _("Notification Preferences")
+        user = self._get_user()
+        if "pk" in self.kwargs:
+            # Only admin should access other users preferences
+            context["username"] = user.username
+            context["title"] += f" ({user.username})"
         context["user_id"] = user.id
         return context
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #462.

## Description of Changes

Restricts direct access to the user notification preferences page so it only opens for staff users and superusers.

If the target user is a regular non-staff account, the view redirects to the admin index and shows a translatable error message explaining that notification preferences are only available for staff users or superusers.

Added regression coverage for the redirect/message behavior and updated the existing preference page test to use a staff target user for the allowed access case.

## Screenshot

Not applicable: this is a redirect/error-message behavior covered by tests.