### PR TITLE
[chores:fix] Removed deprecated UUIDAdmin in favour of CopyableFieldsAdmin

### DIFF
--- a/openwisp_notifications/widgets.py
+++ b/openwisp_notifications/widgets.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-from openwisp_utils.admin import UUIDAdmin
+from openwisp_utils.admin import CopyableFieldsAdmin
 
 
 class IgnoreObjectNotificationWidgetMedia:
@@ -42,5 +42,7 @@ def _add_object_notification_widget():
                 )
         except AttributeError:
             model_admin_class.Media = IgnoreObjectNotificationWidgetMedia
-            # Needed tp maintain order or JS imports.
-            model_admin_class.Media.js = UUIDAdmin.Media.js + model_admin_class.Media.js
+            # Needed to maintain order or JS imports.
+            model_admin_class.Media.js = (
+                CopyableFieldsAdmin.Media.js + model_admin_class.Media.js
+            )


### PR DESCRIPTION
Removed deprecated `UUIDAdmin` in favour of `CopyableFieldsAdmin`.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.