### PR TITLE
[chores:fix] Preserved text -> jsonb migration for JSONField fields #467

### DIFF
--- a/openwisp_notifications/migrations/0001_initial.py
+++ b/openwisp_notifications/migrations/0001_initial.py
@@ -159,7 +159,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "data",
-                    models.JSONField(blank=True, null=True, verbose_name="data"),
+                    models.TextField(blank=True, null=True, verbose_name="data"),
                 ),
                 (
                     "id",

--- a/tests/openwisp2/sample_notifications/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_notifications/migrations/0001_initial.py
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "data",
-                    models.JSONField(blank=True, null=True, verbose_name="data"),
+                    models.TextField(blank=True, null=True, verbose_name="data"),
                 ),
                 (
                     "id",


### PR DESCRIPTION




## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #467

## Description of Changes

Historical migrations were updated to use models.TextField instead of models.JSONField for fields originally backed by the third-party jsonfield library.

The original jsonfield.fields.JSONField inherited from TextField and stored values as PostgreSQL text. Replacing historical migration definitions with models.JSONField caused Django to interpret the migration transition as JSONField -> JSONField, resulting in a no-op migration and preventing PostgreSQL columns from being converted to jsonb.

By preserving the historical field semantics as TextField, Django can correctly detect the transition from text -> jsonb and generate the required ALTER COLUMN ... TYPE jsonb migration SQL during upgrades.
