### PR TITLE
[docs] Document WebSocket API real-time notifications #443

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ within the OpenWISP architecture.
     ./user/notification-preferences.rst
     ./user/scheduled-deletion-of-notifications.rst
     ./user/rest-api.rst
+    ./user/websocket-api.rst
     ./user/settings.rst
     ./user/management-commands.rst
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -181,6 +181,9 @@ over.
 
 This setting allows tweaking how this mechanism works.
 
+For details on how the storm prevention affects real-time WebSocket
+delivery, refer to the :doc:`WebSocket API reference <websocket-api>`.
+
 The default configuration is as follows:
 
 .. code-block:: python

--- a/docs/user/web-email-notifications.rst
+++ b/docs/user/web-email-notifications.rst
@@ -43,6 +43,10 @@ when many notifications arrive in a short time. Refer to
 :ref:`openwisp_notifications_notification_storm_prevention` for more
 information.
 
+Real-time notification delivery uses the :doc:`WebSocket API
+<websocket-api>`, which also handles storm backoff and widget reload
+signaling.
+
 .. _notifications_email_notifications:
 
 Email Notifications

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -21,7 +21,7 @@ All endpoints:
 .. _notifications_websocket_authentication:
 
 Authentication and Authorization
----------------------------------
+--------------------------------
 
 The WebSocket endpoint requires an authenticated user. Authentication
 relies on the standard Django session: connect from a browser context
@@ -52,7 +52,7 @@ Real-time notification events for the authenticated user.
 .. _notifications_websocket_server_to_client:
 
 Server-to-Client Messages
-++++++++++++++++++++++++++
++++++++++++++++++++++++++
 
 After the connection is established, the server pushes a message every
 time a notification is created, read, or deleted for the connected user.
@@ -78,20 +78,21 @@ time a notification is created, read, or deleted for the connected user.
 The ``notification`` field is ``null`` in the following cases:
 
 - The notification was marked as read or deleted (no toast needed).
-- A :ref:`notification storm <openwisp_notifications_notification_storm_prevention>`
-  is in progress: the server throttles toast delivery to avoid flooding
-  the client. The widget still reloads to reflect the updated count when
-  ``reload_widget`` is ``true``.
+- A :ref:`notification storm
+  <openwisp_notifications_notification_storm_prevention>` is in progress:
+  the server throttles toast delivery to avoid flooding the client. The
+  widget still reloads to reflect the updated count when ``reload_widget``
+  is ``true``.
 
 .. _notifications_websocket_client_to_server:
 
 Client-to-Server Messages
-++++++++++++++++++++++++++
++++++++++++++++++++++++++
 
 The client can send the following message types to the server.
 
 Mark a Notification as Read
-''''''''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Send this message to mark a single notification as read:
 
@@ -112,11 +113,11 @@ If the ``notification_id`` does not belong to the authenticated user, or
 the notification does not exist, the message is silently ignored.
 
 Retrieve Object Notification Mute Status
-''''''''''''''''''''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Send this message to check whether notifications for a specific object
-are muted for the authenticated user (i.e. an
-``IgnoreObjectNotification`` record exists):
+Send this message to check whether notifications for a specific object are
+muted for the authenticated user (i.e. an ``IgnoreObjectNotification``
+record exists):
 
 .. code-block:: javascript
 
@@ -133,7 +134,7 @@ If a matching mute record exists, the server responds with:
 
     {
         "type": "object_notification",
-        "valid_till": "<datetime>"    // ISO 8601 datetime until which notifications are muted
+        "valid_till": "<datetime>"    // ISO 8601 datetime until which notifications are muted; null means permanently muted
     }
 
 If no mute record exists for the given object, the server sends no

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -61,8 +61,8 @@ time a notification is created, read, or deleted for the connected user.
 
     {
         "type": "notification",
-        "notification_count": 3,          // Unread count; returns "99+" when count exceeds 99
-        "reload_widget": true,            // Whether the client should reload the notification widget
+        "notification_count": 3,          // Unread count (integer, or "99+" string when count exceeds 99)
+        "reload_widget": true,            // Whether the client should reload the notification widget; false during notification storm throttling
         "notification": {                 // null when no toast should be shown (e.g. on read/delete or during a notification storm)
             "id": "<uuid>",
             "message": "<string>",        // Short notification message
@@ -80,9 +80,11 @@ The ``notification`` field is ``null`` in the following cases:
 - The notification was marked as read or deleted (no toast needed).
 - A :ref:`notification storm
   <openwisp_notifications_notification_storm_prevention>` is in progress:
-  the server throttles toast delivery to avoid flooding the client. The
-  widget still reloads to reflect the updated count when ``reload_widget``
-  is ``true``.
+  the server applies a backoff strategy that throttles toast delivery and
+  may set ``reload_widget`` to ``false`` to suppress widget reloads during
+  the storm window. The widget reloads periodically based on the
+  ``max_allowed_backoff`` interval defined in the storm prevention
+  settings.
 
 .. _notifications_websocket_client_to_server:
 

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -1,0 +1,140 @@
+WebSocket API Reference
+=======================
+
+.. contents:: **Table of Contents**:
+    :depth: 2
+    :local:
+
+Overview
+--------
+
+The WebSocket API provides real-time, push-based notification updates to
+connected clients.
+
+All endpoints:
+
+- Use JSON-encoded messages on the wire.
+- Push real-time updates to the client after a connection is established.
+- Accept specific client messages to perform actions (e.g., marking a
+  notification as read).
+
+.. _notifications_websocket_authentication:
+
+Authentication and Authorization
+---------------------------------
+
+The WebSocket endpoint requires an authenticated user. Authentication
+relies on the standard Django session: connect from a browser context
+where the user is already logged in so that the session cookie is sent
+during the WebSocket handshake.
+
+The connection is closed immediately if authentication fails.
+
+Connection Endpoints
+--------------------
+
+.. _notifications_websocket_endpoint:
+
+Notification Updates
+~~~~~~~~~~~~~~~~~~~~
+
+Connection URL:
+
+::
+
+    wss://<host>/ws/notification/
+
+Scope
++++++
+
+Real-time notification events for the authenticated user.
+
+.. _notifications_websocket_server_to_client:
+
+Server-to-Client Messages
+++++++++++++++++++++++++++
+
+After the connection is established, the server pushes a message every
+time a notification is created, read, or deleted for the connected user.
+
+.. code-block:: javascript
+
+    {
+        "type": "notification",
+        "notification_count": 3,          // Unread count; returns "99+" when count exceeds 99
+        "reload_widget": true,            // Whether the client should reload the notification widget
+        "notification": {                 // null when no toast should be shown (e.g. on read/delete or during a notification storm)
+            "id": "<uuid>",
+            "message": "<string>",        // Short notification message
+            "description": "<string>",    // Full rendered description (may contain HTML)
+            "unread": true,
+            "target_url": "<url>",        // URL to the related object (nullable)
+            "email_subject": "<string>",  // Subject line used for the email notification
+            "timestamp": "<datetime>",    // ISO 8601 creation timestamp
+            "level": "<string>"           // Severity level: "info", "warning" or "error"
+        }
+    }
+
+The ``notification`` field is ``null`` in the following cases:
+
+- The notification was marked as read or deleted (no toast needed).
+- A :ref:`notification storm <openwisp_notifications_notification_storm_prevention>`
+  is in progress: the server throttles toast delivery to avoid flooding
+  the client. The widget still reloads to reflect the updated count when
+  ``reload_widget`` is ``true``.
+
+.. _notifications_websocket_client_to_server:
+
+Client-to-Server Messages
+++++++++++++++++++++++++++
+
+The client can send the following message types to the server.
+
+Mark a Notification as Read
+''''''''''''''''''''''''''''
+
+Send this message to mark a single notification as read:
+
+.. code-block:: javascript
+
+    {
+        "type": "notification",
+        "notification_id": "<uuid>"   // ID of the notification to mark as read
+    }
+
+The server does not send a dedicated acknowledgement response. Instead,
+marking a notification as read triggers the server to push a standard
+:ref:`server-to-client message <notifications_websocket_server_to_client>`
+with the updated ``notification_count`` and ``notification`` set to
+``null``.
+
+If the ``notification_id`` does not belong to the authenticated user, or
+the notification does not exist, the message is silently ignored.
+
+Retrieve Object Notification Mute Status
+''''''''''''''''''''''''''''''''''''''''
+
+Send this message to check whether notifications for a specific object
+are muted for the authenticated user (i.e. an
+``IgnoreObjectNotification`` record exists):
+
+.. code-block:: javascript
+
+    {
+        "type": "object_notification",
+        "app_label": "<string>",      // Django app label of the target model (e.g. "config")
+        "model_name": "<string>",     // Model name in lowercase (e.g. "device")
+        "object_id": "<uuid>"         // Primary key of the target object
+    }
+
+If a matching mute record exists, the server responds with:
+
+.. code-block:: javascript
+
+    {
+        "type": "object_notification",
+        "valid_till": "<datetime>"    // ISO 8601 datetime until which notifications are muted
+    }
+
+If no mute record exists for the given object, the server sends no
+response.


### PR DESCRIPTION
 Added `docs/user/websocket-api.rst` covering the `ws/notification/` Django Channels endpoint: connection URL, session-cookie authentication, server-to-client `notification` messages (including the `notification_count`, `reload_widget`, and `notification` payload fields), client-to-server messages for marking a notification read and querying object-mute status, and the corresponding server response for `object_notification` queries.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #443 .

## Description of Changes
Added a new ``docs/user/websocket-api.rst`` page documenting the ``ws/notification/`` endpoint: connection URL, session-cookie authentication, server-to-client message fields, and client-to-server messages for marking notifications read and querying object-mute status. The page is linked from the main docs index.
