### PR TITLE
[chores] Standardized REST API pagination

### DIFF
--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -12,7 +12,6 @@ from rest_framework.generics import (
     get_object_or_404,
 )
 from rest_framework.mixins import CreateModelMixin, ListModelMixin, UpdateModelMixin
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -29,6 +28,7 @@ from openwisp_notifications.api.serializers import (
 from openwisp_notifications.swapper import load_model
 from openwisp_users.api.authentication import BearerAuthentication
 from openwisp_users.api.mixins import ProtectedAPIMixin
+from openwisp_utils.api.pagination import OpenWispPagination
 
 from .filters import NotificationSettingFilter
 
@@ -43,10 +43,8 @@ OrganizationNotificationSettings = load_model("OrganizationNotificationSettings"
 IgnoreObjectNotification = load_model("IgnoreObjectNotification")
 
 
-class NotificationPaginator(PageNumberPagination):
+class NotificationPaginator(OpenWispPagination):
     page_size = 20
-    page_size_query_param = "page_size"
-    max_page_size = 100
 
 
 class BaseNotificationView(GenericAPIView):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

References https://github.com/openwisp/openwisp-utils/issues/586.

## Description of Changes

Replaces endpoint-specific DRF paginator classes with the shared `OpenWispPagination` implementation introduced in https://github.com/openwisp/openwisp-utils/pull/587.

This change reduces duplication and keeps pagination behavior consistent across OpenWISP modules. The notifications API keeps its existing `page_size = 20` behavior.

## Screenshot

N/A.