### PR TITLE
[change] Make Notification.type non-nullable #481

### DIFF
--- a/docs/developer/sending-notifications.rst
+++ b/docs/developer/sending-notifications.rst
@@ -52,7 +52,8 @@ The complete syntax for ``notify`` is:
 .. code-block:: python
 
     notify.send(
-        actor,
+        sender,
+        type,
         recipient,
         verb,
         action_object,
@@ -87,8 +88,7 @@ The ``notify`` signal supports the following parameters:
 ``type``          Set values of other parameters based on registered
                   :doc:`notification types <./notification-types>`
 
-                  Defaults to ``None`` meaning you need to provide other
-                  arguments.
+                  This parameter is required.
 ``email_subject`` Sets subject of email notification to be sent.
 
                   Defaults to the notification message.

--- a/docs/developer/sending-notifications.rst
+++ b/docs/developer/sending-notifications.rst
@@ -64,113 +64,51 @@ The complete syntax for ``notify`` is:
     )
 
 The ``notify`` signal supports the following parameters:
-**Parameter**     **Description**
-``actor``         An object of any type that represents the actor
-                  performing the action that triggered the notification.
 
-                  **Note:** Use ``sender`` instead of ``actor`` if you
-                  intend to use keyword arguments.
-``recipient``     The recipient of the notification. This can be a
-                  ``Group``, a list or queryset of ``User`` objects, or a
-                  single ``User`` object.
+``actor`` An object of any type that represents the actor
+    performing the action that triggered the notification. **Note:** Use
+    ``sender`` instead of ``actor`` if you intend to use keyword
+    arguments.
 
-                  Defaults to ``None``, meaning you need to provide this
-                  argument.
+``recipient`` The recipient of the notification. This can be a
+    ``Group``, a list or queryset of ``User`` objects, or a single
+    ``User`` object. Defaults to ``None``, meaning you need to provide
+    this argument.
+
 ``action_object`` An object related to the action that triggered the
-                  notification (optional).
+    notification (optional). Defaults to ``None``.
 
-                  Defaults to ``None``.
-``target``        The target object of the notification (optional).
+``target`` The target object of the notification (optional).
+    Defaults to ``None``.
 
-                  Defaults to ``None``.
-``type``          Set values of other parameters based on registered
-                  :doc:`notification types <./notification-types>`
-
-                  This parameter is required.
-``email_subject`` Sets subject of email notification to be sent.
-
-                  Defaults to the notification message.
-``url``           Adds a URL in the email text, e.g.:
-
-                  ``For more information see <url>.``
-
-                  Defaults to ``None``, meaning the above message would
-                  not be added to the email text.
-``verb``          A string describing the action that triggered the
-                  notification.
-
-                  Defaults to ``None``, meaning you need to provide this
-                  argument.
-``level``         The level of the notification, one of 'success', 'info',
-                  'warning' or 'error'.
-
-                  Defaults to 'info'.
-``description``   Additional information to be included in the
-                  notification (optional).
-
-                  Defaults to ``''``.
-``timestamp``     A timestamp (``datetime`` object) for the notification
-                  (optional).
-
-                  Defaults to the current time.
-**Parameter**         **Description**
-``actor``             An object of any type that represents the actor
-                      performing the action that triggered the
-                      notification.
-
-                      **Note:** Use ``sender`` instead of ``actor`` if you
-                      intend to use keyword arguments.
-``recipient``         The recipient of the notification. This can be a
-                      ``Group``, a list or queryset of ``User`` objects,
-                      or a single ``User`` object.
-
-                      Defaults to ``None``, meaning you need to provide
-                      this argument.
-``action_object``     An object related to the action that triggered the
-                      notification (optional).
-
-                      Defaults to ``None``.
-``target``            The target object of the notification (optional).
-
-                      Defaults to ``None``.
 ``target_url_suffix`` Appends a querystring or fragment to the generated
-                      target URL. The value must be a string starting with
-                      ``?``, ``&`` or ``#``. See the :ref:`generic_message
-                      example <notifications_generic_message_type>`.
+    target URL. The value must be a string starting with ``?``, ``&`` or
+    ``#``. See the :ref:`generic_message example
+    <notifications_generic_message_type>`. Defaults to ``None``.
 
-                      Defaults to ``None``.
-``type``              Set values of other parameters based on registered
-                      :doc:`notification types <./notification-types>`
+``type`` Set values of other parameters based on registered
+    :doc:`notification types <./notification-types>`. Defaults to ``None``
+    meaning you need to provide other arguments.
 
-                      Defaults to ``None`` meaning you need to provide
-                      other arguments.
-``email_subject``     Sets subject of email notification to be sent.
+``email_subject`` Sets subject of email notification to be sent.
+    Defaults to the notification message.
 
-                      Defaults to the notification message.
-``url``               Adds a URL in the email text, e.g.:
+``url`` Adds a URL in the email text, e.g.:
+    ``For more information see <url>.``. Defaults to ``None``, meaning the
+    above message would not be added to the email text.
 
-                      ``For more information see <url>.``
+``verb`` A string describing the action that triggered the
+    notification. Defaults to ``None``, meaning you need to provide this
+    argument.
 
-                      Defaults to ``None``, meaning the above message
-                      would not be added to the email text.
-``verb``              A string describing the action that triggered the
-                      notification.
+``level`` The level of the notification, one of 'success',
+    'info', 'warning' or 'error'. Defaults to 'info'.
 
-                      Defaults to ``None``, meaning you need to provide
-                      this argument.
-``level``             The level of the notification, one of 'success',
-                      'info', 'warning' or 'error'.
+``description`` Additional information to be included in the
+    notification (optional). Defaults to ``''``.
 
-                      Defaults to 'info'.
-``description``       Additional information to be included in the
-                      notification (optional).
-
-                      Defaults to ``''``.
-``timestamp``         A timestamp (``datetime`` object) for the
-                      notification (optional).
-
-                      Defaults to the current time.
-
+``timestamp`` A timestamp (``datetime`` object) for the
+    notification (optional). Defaults to the current time.
 
 Passing Extra Data to Notifications
 -----------------------------------

--- a/docs/developer/sending-notifications.rst
+++ b/docs/developer/sending-notifications.rst
@@ -56,8 +56,9 @@ The ``notify`` signal supports the following parameters:
 
 ``recipient`` The recipient of the notification. This can be a
     ``Group``, a list or queryset of ``User`` objects, or a single
-    ``User`` object. Defaults to ``None``, meaning you need to provide
-    this argument.
+    ``User`` object. Defaults to ``None``. If omitted, eligible superusers
+    and, when the target has an organization, its administrators are
+    notified.
 
 ``action_object`` An object related to the action that triggered the
     notification (optional). Defaults to ``None``.
@@ -75,18 +76,18 @@ The ``notify`` signal supports the following parameters:
     required.
 
 ``email_subject`` Sets subject of email notification to be sent.
-    Defaults to the notification message.
+    Uses the registered notification type's email subject configuration.
 
 ``url`` Adds a URL in the email text, e.g.:
     ``For more information see <url>.``. Defaults to ``None``, meaning the
     above message would not be added to the email text.
 
 ``verb`` A string describing the action that triggered the
-    notification. Defaults to ``None``, meaning you need to provide this
-    argument.
+    notification. Uses the registered notification type's configured verb.
 
 ``level`` The level of the notification, one of 'success',
-    'info', 'warning' or 'error'. Defaults to 'info'.
+    'info', 'warning' or 'error'. Uses the registered notification type's
+    configured level.
 
 ``description`` Additional information to be included in the
     notification (optional). Defaults to ``''``.

--- a/docs/developer/sending-notifications.rst
+++ b/docs/developer/sending-notifications.rst
@@ -47,22 +47,6 @@ You can override the recipients of the notification by passing the
 However, these users will only be notified if they have opted-in to
 receive notifications.
 
-The complete syntax for ``notify`` is:
-
-.. code-block:: python
-
-    notify.send(
-        sender,
-        type,
-        recipient,
-        verb,
-        action_object,
-        target,
-        level,
-        description,
-        **kwargs,
-    )
-
 The ``notify`` signal supports the following parameters:
 
 ``actor`` An object of any type that represents the actor
@@ -87,8 +71,8 @@ The ``notify`` signal supports the following parameters:
     <notifications_generic_message_type>`. Defaults to ``None``.
 
 ``type`` Set values of other parameters based on registered
-    :doc:`notification types <./notification-types>`. Defaults to ``None``
-    meaning you need to provide other arguments.
+    :doc:`notification types <./notification-types>`. This parameter is
+    required.
 
 ``email_subject`` Sets subject of email notification to be sent.
     Defaults to the notification message.

--- a/openwisp_notifications/base/models.py
+++ b/openwisp_notifications/base/models.py
@@ -84,7 +84,6 @@ class AbstractNotification(UUIDModel, BaseNotification):
     CACHE_KEY_PREFIX = "ow-notifications-"
     type = models.CharField(
         max_length=30,
-        null=True,
         # TODO: Remove when dropping support for Django 4.2
         choices=(
             NOTIFICATION_CHOICES
@@ -216,16 +215,15 @@ class AbstractNotification(UUIDModel, BaseNotification):
         """
         Returns URLs for "actor", "action_object" and "target" fields.
         """
-        if self.type:
-            # Generate URL according to the notification configuration
-            config = get_notification_configuration(self.type)
-            url = config.get(f"{field}_link", None)
-            if url:
-                try:
-                    url_callable = import_string(url)
-                    return url_callable(self, field=field, absolute_url=True)
-                except ImportError:
-                    return url
+        # Generate URL according to the notification configuration
+        config = get_notification_configuration(self.type)
+        url = config.get(f"{field}_link", None)
+        if url:
+            try:
+                url_callable = import_string(url)
+                return url_callable(self, field=field, absolute_url=True)
+            except ImportError:
+                return url
         return _get_object_link(obj=self._related_object(field), absolute_url=True)
 
     @property
@@ -260,8 +258,6 @@ class AbstractNotification(UUIDModel, BaseNotification):
             return self.get_message()
 
     def get_message(self):
-        if not self.type:
-            return self.description
         try:
             config = get_notification_configuration(self.type)
             data = self.data or {}
@@ -283,23 +279,18 @@ class AbstractNotification(UUIDModel, BaseNotification):
 
     @cached_property
     def email_subject(self):
-        if self.type:
-            try:
-                config = get_notification_configuration(self.type)
-                data = self.data or {}
-                return config["email_subject"].format(
-                    site=Site.objects.get_current(), notification=self, **data
-                )
-            except (AttributeError, KeyError, NotificationRenderException) as exception:
-                self._invalid_notification(
-                    self.pk,
-                    exception,
-                    "Error encountered in generating notification email",
-                )
-        elif self.data.get("email_subject", None):
-            return self.data.get("email_subject")
-        else:
-            return self.message
+        try:
+            config = get_notification_configuration(self.type)
+            data = self.data or {}
+            return config["email_subject"].format(
+                site=Site.objects.get_current(), notification=self, **data
+            )
+        except (AttributeError, KeyError, NotificationRenderException) as exception:
+            self._invalid_notification(
+                self.pk,
+                exception,
+                "Error encountered in generating notification email",
+            )
 
     def _related_object(self, field):
         obj_id = getattr(self, f"{field}_object_id")

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -54,7 +54,7 @@ def notify_handler(**kwargs):
     description = kwargs.pop("description", None)
     timestamp = kwargs.pop("timestamp", timezone.now())
     recipient = kwargs.pop("recipient", None)
-    notification_type = kwargs.pop("type", None)
+    notification_type = kwargs.pop("type")
     target = kwargs.get("target", None)
     target_org = getattr(target, "organization_id", None)
     try:
@@ -88,33 +88,28 @@ def notify_handler(**kwargs):
         # chain can still resolve to True. Org-level web settings
         # are resolved via JOINs in the main query to avoid an
         # additional OrganizationNotificationSettings lookup.
-        if notification_type:
-            web_notification = Q(notificationsetting__web=True)
-            if notification_template["web_notification"]:
-                # Users with web=None inherit the org setting, so
-                # include them unless the org explicitly disables
-                # web notifications.
-                web_notification |= Q(
-                    notificationsetting__web=None,
-                ) & (
-                    Q(
-                        notificationsetting__organization__notification_settings__web=True
-                    )
-                    | Q(
-                        notificationsetting__organization__notification_settings__web=None
-                    )
-                    | Q(
-                        notificationsetting__organization__notification_settings__isnull=True
-                    )
+        web_notification = Q(notificationsetting__web=True)
+        if notification_template["web_notification"]:
+            # Users with web=None inherit the org setting, so
+            # include them unless the org explicitly disables
+            # web notifications.
+            web_notification |= Q(
+                notificationsetting__web=None,
+            ) & (
+                Q(notificationsetting__organization__notification_settings__web=True)
+                | Q(notificationsetting__organization__notification_settings__web=None)
+                | Q(
+                    notificationsetting__organization__notification_settings__isnull=True
                 )
-
-            notification_setting = web_notification & Q(
-                notificationsetting__type=notification_type,
-                notificationsetting__organization_id=target_org,
-                notificationsetting__deleted=False,
             )
-            where = where & notification_setting
-            where_group = where_group & notification_setting
+
+        notification_setting = web_notification & Q(
+            notificationsetting__type=notification_type,
+            notificationsetting__organization_id=target_org,
+            notificationsetting__deleted=False,
+        )
+        where = where & notification_setting
+        where_group = where_group & notification_setting
 
     # Ensure notifications are only sent to active user
     where = where & Q(is_active=True)

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -54,7 +54,9 @@ def notify_handler(**kwargs):
     description = kwargs.pop("description", None)
     timestamp = kwargs.pop("timestamp", timezone.now())
     recipient = kwargs.pop("recipient", None)
-    notification_type = kwargs.pop("type")
+    notification_type = kwargs.pop("type", None)
+    if not notification_type:
+        raise ValueError(_("Notification type is required."))
     target = kwargs.get("target", None)
     target_org = getattr(target, "organization_id", None)
     try:

--- a/openwisp_notifications/migrations/0013_make_notification_type_nonnullable.py
+++ b/openwisp_notifications/migrations/0013_make_notification_type_nonnullable.py
@@ -1,0 +1,27 @@
+import django
+from django.db import migrations, models
+
+from openwisp_notifications.types import NOTIFICATION_CHOICES, get_notification_choices
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("openwisp_notifications", "0012_replace_jsonfield_with_django_builtin"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="notification",
+            name="type",
+            field=models.CharField(
+                choices=(
+                    NOTIFICATION_CHOICES
+                    if django.VERSION < (5, 0)
+                    else get_notification_choices
+                ),
+                max_length=30,
+                verbose_name="Notification Type",
+            ),
+        ),
+    ]

--- a/openwisp_notifications/tests/__init__.py
+++ b/openwisp_notifications/tests/__init__.py
@@ -7,16 +7,16 @@ _test_batch_email_notification_email_body = """
   Date & Time: {datetime_str}
   URL: https://example.com/api/v1/notifications/notification/{notification_id}/redirect/
 
-- Test Notification
+- Default notification with default verb and level info by None
   Description: Test Notification
   Date & Time: {datetime_str}
 
-- Test Notification
+- Default notification with default verb and level info by None
   Description: Test Notification
   Date & Time: {datetime_str}
   URL: https://localhost:8000/admin
 
-- Test Notification
+- Default notification with default verb and level info by None
   Description: Test Notification
   Date & Time: {datetime_str}
   URL: https://localhost:8000/admin
@@ -76,7 +76,7 @@ _test_batch_email_notification_email_html = """
                 <div>
                   <span class="badge info">info</span>
                   <div class="title">
-                    <p>Test Notification</p>
+                    <p>Default notification with default verb and level info by None</p>
                   </div>
                 </div>
               </td>
@@ -101,7 +101,7 @@ _test_batch_email_notification_email_html = """
                   <div>
                     <span class="badge info">info</span>
                     <div class="title">
-                      <p>Test Notification</p>
+                      <p>Default notification with default verb and level info by None</p>
                     </div>
                   </div>
                 </td>
@@ -127,7 +127,7 @@ _test_batch_email_notification_email_html = """
                   <div>
                     <span class="badge info">info</span>
                     <div class="title">
-                      <p>Test Notification</p>
+                      <p>Default notification with default verb and level info by None</p>
                     </div>
                   </div>
                 </td>

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -63,6 +63,7 @@ class BaseTestAdmin(TestMultitenantAdminMixin, TestCase):
             description="Test Notification",
             verb="Test Notification",
             email_subject="Test Email subject",
+            type="default",
             url="localhost:8000/admin",
         )
         self.site = AdminSite()

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -77,6 +77,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             description="Test Notification",
             verb="Test Notification",
             email_subject="Test Email subject",
+            type="default",
             url="https://localhost:8000/admin",
         )
 
@@ -93,6 +94,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             recipient=self.admin,
             description="Test Notification Description",
             verb="Test Notification",
+            type="default",
             action_object=operator,
             target=operator,
             data=data,
@@ -111,7 +113,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             n.target_content_type, ContentType.objects.get_for_model(operator)
         )
         self.assertEqual(n.verb, "Test Notification")
-        self.assertEqual(n.message, "Test Notification Description")
+        self.assertIn("Default notification with", n.message)
         self.assertEqual(n.recipient, self.admin)
 
     def test_lazy_translation(self):
@@ -126,6 +128,7 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             description=gettext_lazy("Test Notification"),
             verb=gettext_lazy("Test Notification"),
             email_subject=gettext_lazy("Test Email subject"),
+            type="default",
             url="https://localhost:8000/admin",
             message=gettext_lazy("Translated message"),
             random=gettext_lazy("any extra kwargs is evaluated"),
@@ -253,9 +256,8 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         n = notification_queryset.first()
         self.assertEqual(
             mail.outbox[0].subject,
-            "Test Email subject",
+            n.email_subject,
         )
-        self.assertIn(n.message, mail.outbox[0].body)
         self.assertIn(n.data.get("url"), mail.outbox[0].body)
         self.assertIn("https://", n.data.get("url"))
         html_email = mail.outbox[0].alternatives[0][0]
@@ -362,9 +364,10 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
     def test_description_in_email_subject(self):
         self.notification_options.pop("email_subject")
         self._create_notification()
+        n = notification_queryset.first()
         self.assertEqual(
             mail.outbox[0].subject,
-            "Test Notification",
+            n.email_subject,
         )
 
     def test_handler_optional_tag(self):
@@ -1993,6 +1996,7 @@ class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):
             level="info",
             verb="Test Notification",
             email_subject="Test Email subject",
+            type="default",
             url="https://localhost:8000/admin",
         )
 

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -84,6 +84,21 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
     def _create_notification(self, **kwargs):
         return notify.send(**self.notification_options, **kwargs)
 
+    def test_type_required(self):
+        self.admin.emailaddress_set.update(verified=False)
+        options = self.notification_options.copy()
+        options.pop("type")
+        invalid_types = {
+            "missing": {},
+            "none": {"type": None},
+            "empty": {"type": ""},
+        }
+        for label, invalid_type in invalid_types.items():
+            with self.subTest(type=label):
+                with self.assertRaisesRegex(ValueError, "type is required"):
+                    notify.send(**options, **invalid_type)
+                self.assertFalse(notification_queryset.exists())
+
     def test_create_notification(self):
         operator = super()._create_operator()
         data = dict(

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -323,11 +323,10 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
         self._create_notification()
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.admin.email])
-        n = notification_queryset.first()
         self.assertEqual(
-            mail.outbox[0].subject,
-            n.email_subject,
+            mail.outbox[0].subject, "[example.com] Default Notification Subject"
         )
+        n = notification_queryset.first()
         self.assertIn(n.data.get("url"), mail.outbox[0].body)
         self.assertIn("https://", n.data.get("url"))
         html_email = mail.outbox[0].alternatives[0][0]
@@ -430,15 +429,6 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
                 self.assertEqual(notification.recipient, user)
         else:
             self.fail()
-
-    def test_description_in_email_subject(self):
-        self.notification_options.pop("email_subject")
-        self._create_notification()
-        n = notification_queryset.first()
-        self.assertEqual(
-            mail.outbox[0].subject,
-            n.email_subject,
-        )
 
     def test_handler_optional_tag(self):
         operator = self._create_operator()

--- a/openwisp_notifications/utils.py
+++ b/openwisp_notifications/utils.py
@@ -163,10 +163,6 @@ def get_user_email_preference(notification):
     configuration when the target has no organization.
     """
     target_org = getattr(getattr(notification, "target", None), "organization_id", None)
-    if not notification.type:
-        # notify.send() may create notifications without a type; when no type is
-        # available, default to email notifications being enabled.
-        return True
     if not target_org:
         type_config = get_notification_configuration(notification.type)
         return type_config.get("email_notification", True)

--- a/tests/openwisp2/sample_notifications/migrations/0005_make_notification_type_nonnullable.py
+++ b/tests/openwisp2/sample_notifications/migrations/0005_make_notification_type_nonnullable.py
@@ -1,0 +1,27 @@
+import django
+from django.db import migrations, models
+
+from openwisp_notifications.types import NOTIFICATION_CHOICES, get_notification_choices
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sample_notifications", "0004_replace_jsonfield_with_django_builtin"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="notification",
+            name="type",
+            field=models.CharField(
+                choices=(
+                    NOTIFICATION_CHOICES
+                    if django.VERSION < (5, 0)
+                    else get_notification_choices
+                ),
+                max_length=30,
+                verbose_name="Notification Type",
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation. 

 ## changes

Made `type` required for notifications — removed the nullable fallback and all the `if type is None` guard code across models, handlers, and utils. `NotificationSetting.type` stays nullable since that is intentional for global/all-types settings.
- `notify.send()` now requires `type`
- `Notification.type` is non-nullable (with migration)
- All type=None guard branches removed from notification creation/rendering
- Tests updated to always pass `type="default"`


Closes #481