### PR TITLE
[chores] Separated session redis bucket from cache bucket

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -113,11 +113,18 @@ TEMPLATES = [
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://localhost/5",
+        "LOCATION": "redis://localhost/0",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-    }
+    },
+    "sessions": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://localhost/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    },
 }
 
 ASGI_APPLICATION = "openwisp2.asgi.application"
@@ -131,7 +138,7 @@ else:
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",
             "CONFIG": {
-                "hosts": ["redis://localhost/7"],
+                "hosts": ["redis://localhost/3"],
                 "group_expiry": 3600,
                 "capacity": 1000,
                 "expiry": 30,
@@ -140,7 +147,7 @@ else:
     }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
+SESSION_CACHE_ALIAS = "sessions"
 
 LOGGING = {
     "version": 1,
@@ -167,7 +174,7 @@ if not TESTING:
     LOGGING.update({"root": {"level": "INFO", "handlers": ["console"]}})
 
 if not TESTING:
-    CELERY_BROKER_URL = "redis://localhost/6"
+    CELERY_BROKER_URL = "redis://localhost/2"
 else:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Not needed, small improvement being done in all repositories.

## Description of Changes

Small improvement to the test env which separates cache from session storage to avoid terminating sessions when clearing the cache.