### PR TITLE
[tests] Used browser error helper in Selenium tests

### DIFF
--- a/openwisp_notifications/tests/test_selenium.py
+++ b/openwisp_notifications/tests/test_selenium.py
@@ -143,7 +143,7 @@ class TestSelenium(
             self.assertEqual(
                 self.find_element(By.TAG_NAME, "h2").text, "Invalid or Expired Link"
             )
-            self.assertEqual(len(self.get_browser_logs()), 0)
+            self.assertEqual(self.get_browser_errors(), [])
 
         with self.subTest("User unsubscribe with valid URL"):
             unsubscribe_link = get_unsubscribe_url_for_user(self.admin, False)
@@ -156,7 +156,7 @@ class TestSelenium(
             self.wait_for_visibility(By.ID, "confirm-unsubscribed")
             self.wait_for_invisibility(By.ID, "confirm-subscribed")
             self.assertEqual(self.find_element(By.ID, "toggle-btn").text, "Subscribe")
-            self.assertEqual(len(self.get_browser_logs()), 0)
+            self.assertEqual(self.get_browser_errors(), [])
 
         with self.subTest("User subscribe to notifications again"):
             self.open(unsubscribe_link)
@@ -168,7 +168,7 @@ class TestSelenium(
             self.wait_for_visibility(By.ID, "confirm-subscribed")
             self.wait_for_invisibility(By.ID, "confirm-unsubscribed")
             self.assertEqual(self.find_element(By.ID, "toggle-btn").text, "Unsubscribe")
-            self.assertEqual(len(self.get_browser_logs()), 0)
+            self.assertEqual(self.get_browser_errors(), [])
 
         with self.subTest("Network request fails"):
             self.open(unsubscribe_link)


### PR DESCRIPTION
## Summary

This updates notification Selenium tests to use the shared browser error helper when checking that pages do not emit JavaScript errors. The helper avoids treating unrelated browser-internal logs as application failures.