### PR TITLE
[tests] Prevented noisy celery debug info in test env

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -159,7 +159,7 @@ LOGGING = {
             "propagate": False,
         },
         "py.warnings": {"handlers": ["console"], "propagate": False},
-        "celery": {"handlers": ["console"], "level": "DEBUG"},
+        "celery": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Small clean up for the test env, issue not required.

## Description of Changes

Some noisy debugging info from celery made its way to the console output of the test environment, this patches fixes this.
