### PR TITLE
[change] Honor notification data["url"] for the web target link

### DIFF
--- a/openwisp_notifications/api/serializers.py
+++ b/openwisp_notifications/api/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 from django.db import models
 from rest_framework import serializers
@@ -46,6 +47,20 @@ class NotificationSerializer(serializers.ModelSerializer):
     def get_field_names(self, declared_fields, info):
         model_fields = super().get_field_names(declared_fields, info)
         return model_fields + self.Meta.extra_fields
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        url = (instance.data or {}).get("url")
+        if url and self._is_safe_target_url(url):
+            data["target_url"] = url
+        return data
+
+    @staticmethod
+    def _is_safe_target_url(url):
+        """Allows only relative paths or http(s) URLs as the redirect target."""
+        if url.startswith("//"):
+            return False
+        return urlparse(url).scheme in ("", "http", "https")
 
     @property
     def data(self):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -25,6 +25,7 @@ from freezegun import freeze_time
 
 from openwisp_notifications import settings as app_settings
 from openwisp_notifications import tasks, utils
+from openwisp_notifications.api.serializers import NotificationSerializer
 from openwisp_notifications.exceptions import NotificationRenderException
 from openwisp_notifications.handlers import (
     notify_handler,
@@ -770,6 +771,42 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             self.assertEqual(
                 notification.target_url, "https://target.example.com/index#heading"
             )
+
+    def test_target_url_data_override(self):
+        target = self._create_user(username="target", email="target@example.com")
+        self.notification_options.update({"target": target})
+        with self.subTest("data url is used as the notification link"):
+            self._create_notification()
+            n = Notification.objects.first()
+            self.assertEqual(
+                NotificationSerializer(n).data["target_url"],
+                "https://localhost:8000/admin",
+            )
+            self.assertIn(str(target.pk), n.target_url)
+        with self.subTest("a relative data url is honored"):
+            Notification.objects.all().delete()
+            self.notification_options.update({"url": "/admin/?status=pending"})
+            self._create_notification()
+            n = Notification.objects.first()
+            self.assertEqual(
+                NotificationSerializer(n).data["target_url"], "/admin/?status=pending"
+            )
+        with self.subTest("an unsafe scheme falls back to the target object URL"):
+            for unsafe in ("javascript:alert(1)", "//evil.example.com"):
+                Notification.objects.all().delete()
+                self.notification_options.update({"url": unsafe})
+                self._create_notification()
+                n = Notification.objects.first()
+                self.assertEqual(
+                    NotificationSerializer(n).data["target_url"], n.target_url
+                )
+        with self.subTest("falls back to the target object URL without a data url"):
+            Notification.objects.all().delete()
+            self.notification_options.pop("url")
+            self._create_notification()
+            n = Notification.objects.first()
+            self.assertEqual(NotificationSerializer(n).data["target_url"], n.target_url)
+            self.assertIn(str(target.pk), n.target_url)
 
     @capture_any_output()
     @mock_notification_types


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Related to the persistent mass upgrades work in
openwisp/openwisp-firmware-upgrader#436, which needs a `generic_message` notification to link to a filtered admin page without registering a dedicated notification type.

## Description of Changes

The web notification widget links to the serialized `target_url`, which for `generic_message` is always the target object's admin URL. A per-notification `url` passed to `notify.send()` was only used for the email link, so a notification could not point its web link at a specific page without registering a dedicated notification type with a
`target_link`.
This returns `data["url"]` from the serialized `target_url` when it is set, falling back to the target object's URL otherwise, which is consistent with the email link that already uses `data["url"]`. The model `target_url` property is left unchanged, so message templates that render `{target_link}` continue to point at the target object.
