### PR TITLE
[fix] Fixed web notifications received when disabled globally #495

### DIFF
--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -92,17 +92,20 @@ def notify_handler(**kwargs):
         # additional OrganizationNotificationSettings lookup.
         web_notification = Q(notificationsetting__web=True)
         if notification_template["web_notification"]:
-            # Users with web=None inherit the org setting, so
-            # include them unless the org explicitly disables
-            # web notifications.
-            web_notification |= Q(
-                notificationsetting__web=None,
-            ) & (
-                Q(notificationsetting__organization__notification_settings__web=True)
-                | Q(notificationsetting__organization__notification_settings__web=None)
-                | Q(
+            inherit_org_web = Q(
+                notificationsetting__organization__notification_settings__web=True
+            )
+            if app_settings.WEB_ENABLED:
+                inherit_org_web |= Q(
+                    notificationsetting__organization__notification_settings__web=None
+                ) | Q(
                     notificationsetting__organization__notification_settings__isnull=True
                 )
+            web_notification |= (
+                Q(
+                    notificationsetting__web=None,
+                )
+                & inherit_org_web
             )
 
         notification_setting = web_notification & Q(

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -2046,6 +2046,32 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
             self._assert_notification_created(True, target=org_b_target)
             self._assert_email_sent(True)
 
+    def test_web_disabled_globally_org_inherited_setting(self):
+        self._set_user_notification_settings("default", web=None)
+        with patch.object(app_settings, "WEB_ENABLED", False):
+            self._send_notification("default")
+            self._assert_notification_created(False)
+            self._assert_email_sent(False)
+
+    def test_web_disabled_globally_org_inherited_missing_row(self):
+        self._set_user_notification_settings("default", web=None)
+        self.org.notification_settings.delete()
+        with patch.object(app_settings, "WEB_ENABLED", False):
+            self._send_notification("default")
+            self._assert_notification_created(False)
+            self._assert_email_sent(False)
+
+    def test_web_disabled_globally_org_explicitly_enabled(self):
+        web_field = OrganizationNotificationSettings._meta.get_field("web")
+        self._set_user_notification_settings("default", web=None)
+        with patch.object(web_field, "fallback", False), patch.object(
+            app_settings, "WEB_ENABLED", False
+        ):
+            self._set_org_notification_settings(web=True, email=True)
+            self._send_notification("default")
+            self._assert_notification_created(True)
+            self._assert_email_sent(True)
+
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):
     def setUp(self):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -2046,27 +2046,26 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
             self._assert_notification_created(True, target=org_b_target)
             self._assert_email_sent(True)
 
+    @patch.object(app_settings, "WEB_ENABLED", False)
     def test_web_disabled_globally_org_inherited_setting(self):
         self._set_user_notification_settings("default", web=None)
-        with patch.object(app_settings, "WEB_ENABLED", False):
-            self._send_notification("default")
-            self._assert_notification_created(False)
-            self._assert_email_sent(False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
 
+    @patch.object(app_settings, "WEB_ENABLED", False)
     def test_web_disabled_globally_org_inherited_missing_row(self):
         self._set_user_notification_settings("default", web=None)
         self.org.notification_settings.delete()
-        with patch.object(app_settings, "WEB_ENABLED", False):
-            self._send_notification("default")
-            self._assert_notification_created(False)
-            self._assert_email_sent(False)
+        self._send_notification("default")
+        self._assert_notification_created(False)
+        self._assert_email_sent(False)
 
+    @patch.object(app_settings, "WEB_ENABLED", False)
     def test_web_disabled_globally_org_explicitly_enabled(self):
         web_field = OrganizationNotificationSettings._meta.get_field("web")
         self._set_user_notification_settings("default", web=None)
-        with patch.object(web_field, "fallback", False), patch.object(
-            app_settings, "WEB_ENABLED", False
-        ):
+        with patch.object(web_field, "fallback", False):
             self._set_org_notification_settings(web=True, email=True)
             self._send_notification("default")
             self._assert_notification_created(True)

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -2047,29 +2047,33 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
             self._assert_email_sent(True)
 
     @patch.object(app_settings, "WEB_ENABLED", False)
-    def test_web_disabled_globally_org_inherited_setting(self):
+    def test_web_disabled_globally_org_settings_fallback(self):
         self._set_user_notification_settings("default", web=None)
-        self._send_notification("default")
-        self._assert_notification_created(False)
-        self._assert_email_sent(False)
 
-    @patch.object(app_settings, "WEB_ENABLED", False)
-    def test_web_disabled_globally_org_inherited_missing_row(self):
-        self._set_user_notification_settings("default", web=None)
-        self.org.notification_settings.delete()
-        self._send_notification("default")
-        self._assert_notification_created(False)
-        self._assert_email_sent(False)
-
-    @patch.object(app_settings, "WEB_ENABLED", False)
-    def test_web_disabled_globally_org_explicitly_enabled(self):
-        web_field = OrganizationNotificationSettings._meta.get_field("web")
-        self._set_user_notification_settings("default", web=None)
-        with patch.object(web_field, "fallback", False):
-            self._set_org_notification_settings(web=True, email=True)
+        with self.subTest("Organization setting inherited"):
             self._send_notification("default")
-            self._assert_notification_created(True)
-            self._assert_email_sent(True)
+            self._assert_notification_created(False)
+            self._assert_email_sent(False)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+
+        with self.subTest("Organization setting explicitly enabled"):
+            web_field = OrganizationNotificationSettings._meta.get_field("web")
+            with patch.object(web_field, "fallback", False):
+                self._set_org_notification_settings(web=True, email=True)
+                self._send_notification("default")
+                self._assert_notification_created(True)
+                self._assert_email_sent(True)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+
+        with self.subTest("Organization settings missing"):
+            self.org.notification_settings.delete()
+            self._send_notification("default")
+            self._assert_notification_created(False)
+            self._assert_email_sent(False)
 
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):


### PR DESCRIPTION
## Description

Supersedes the previously closed PR #498 (which pointed at the fork `master` branch; per the contributing guidelines this PR uses a dedicated feature branch instead).

## Fixes #495

## Changes

- `notify_handler` now only sends web notifications to users with `web=None` when the organization explicitly enables them, or when the global setting is enabled.
- An explicit organization `web=True` still overrides a disabled global setting.
- Added regression tests covering:
   global disabled + organization inherited setting
  global disabled + missing organization settings row
   global disabled + organization explicitly enabled

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] The pull request does not introduce any new security issues or bugs.
- [x] I have updated the documentation when needed.
- [x] The commit message style is in compliance with the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html).
- [x] The commit message references the issue number (e.g. `Fixes #123`).
