### PR TITLE
[tests] Changed test_cached_invalidation to use generic_message

### DIFF
--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -15,6 +15,7 @@ from openwisp_notifications.swapper import load_model, swapper_load_model
 from openwisp_notifications.templatetags.notification_tags import (
     has_notification_setting_permission,
 )
+from openwisp_notifications.types import NOTIFICATION_TYPES
 from openwisp_notifications.widgets import _add_object_notification_widget
 from openwisp_users.admin import UserAdmin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
@@ -63,7 +64,7 @@ class BaseTestAdmin(TestMultitenantAdminMixin, TestCase):
             description="Test Notification",
             verb="Test Notification",
             email_subject="Test Email subject",
-            type="default",
+            type="generic_message",
             url="localhost:8000/admin",
         )
         self.site = AdminSite()
@@ -110,6 +111,11 @@ class TestAdmin(BaseTestAdmin):
         self.assertEqual(cache.get(cache_key), 0)
         return cache_key
 
+    @patch.dict(
+        NOTIFICATION_TYPES,
+        {"generic_message": NOTIFICATION_TYPES["generic_message"]},
+        clear=True,
+    )
     def test_cached_invalidation(self):
         cache_key = self.test_cached_value()
         notify.send(**self.notification_options)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have updated existing tests for this change.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

`openwisp_controller.config` unregisters the `default` notification type. The cache invalidation test used that type after notification types became mandatory, so no notification was created in the Controller test environment and the cached count was not cleared.

The test now uses `generic_message`, which remains registered. It also runs with `default` removed from the registry, so the Controller case is covered.

## Screenshot

N/A