### PR TITLE
[change] Prevented notifications for disabled organizations #472

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
           pip install -U pip wheel setuptools
           pip install -U -r requirements-test.txt
           pip install -U -e .
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-users/tarball/issues/522-disabled-org
           pip install ${{ matrix.django-version }}
           sudo npm install -g prettier
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ If instructions conflict, repository config and CI workflows win first, official
 - Be careful with notification preference inheritance, global notification settings, soft-deleted `NotificationSetting` rows, and user/organization permission boundaries.
 - Be careful when changing organization membership handling, notification preference APIs, unsubscribe flows, email verification warnings, websocket updates, and cache invalidation.
 - Notification payloads can include related objects and URLs; preserve validation and permission checks when changing serializers, views, handlers, or tasks.
+- Objects belonging to a disabled organization must be readable and deletable; creation and updates must be blocked across all relevant write paths. This applies to objects with either a direct or chained/nested relationship to the organization. No other operations should be permitted, except for ordinary cleanup operations.
 
 ## Troubleshooting
 

--- a/docs/developer/sending-notifications.rst
+++ b/docs/developer/sending-notifications.rst
@@ -37,6 +37,12 @@ organization administrators of the target object's organization who have
 opted-in to receive notifications. If the target object is omitted or does
 not have an organization, it will only send notifications to superusers.
 
+No notification is generated when the target object belongs to a disabled
+organization (``Organization.is_active=False``); notifications without a
+target, or whose target has no organization, are unaffected. Notifications
+created before an organization was disabled remain readable and can still
+be marked as read.
+
 You can override the recipients of the notification by passing the
 ``recipient`` keyword argument. The ``recipient`` argument can be a:
 

--- a/docs/user/notification-preferences.rst
+++ b/docs/user/notification-preferences.rst
@@ -103,6 +103,11 @@ Key points:
 - Organization settings override global defaults defined in Django
   settings (see :ref:`openwisp_notifications_web_enabled` and
   :ref:`openwisp_notifications_email_enabled`).
+- Preferences of disabled organizations are hidden from the preferences
+  page and API, and cannot be modified per organization. The one-click
+  email unsubscribe link is unaffected and still applies to every
+  organization, including disabled ones, so a user's choice does not drift
+  once an organization is re-enabled.
 
 .. _notifications_silencing:
 

--- a/openwisp_notifications/api/views.py
+++ b/openwisp_notifications/api/views.py
@@ -223,19 +223,26 @@ class IgnoreObjectNotificationView(
 
 class UserOrgNotificationSettingView(GenericAPIView):
     """
-    Allows a user to enable or disable all their notifications for a specific organization.
+    Bulk-toggles all of a user's notification settings for one organization.
     """
 
     permission_classes = [IsAuthenticated, PreferencesPermission]
     serializer_class = NotificationSettingUpdateSerializer
 
+    def get_queryset(self):
+        return NotificationSetting.objects.filter(
+            organization_id=self.kwargs["organization_id"],
+            user_id=self.kwargs["user_id"],
+            organization__is_active=True,
+        )
+
     def post(self, request, user_id, organization_id):
+        queryset = self.get_queryset()
+        if not queryset.exists():
+            raise Http404
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
-            validated_data = serializer.validated_data
-            NotificationSetting.objects.filter(
-                organization_id=organization_id, user_id=user_id
-            ).update(**validated_data)
+            queryset.update(**serializer.validated_data)
             return Response(status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/openwisp_notifications/handlers.py
+++ b/openwisp_notifications/handlers.py
@@ -59,6 +59,9 @@ def notify_handler(**kwargs):
         raise ValueError(_("Notification type is required."))
     target = kwargs.get("target", None)
     target_org = getattr(target, "organization_id", None)
+    if target_org and not Organization.active.filter(pk=target_org).exists():
+        # Notifications are not generated for disabled organizations.
+        return
     try:
         notification_template = get_notification_configuration(notification_type)
     except NotificationRenderException as error:

--- a/openwisp_notifications/tests/test_admin.py
+++ b/openwisp_notifications/tests/test_admin.py
@@ -2,14 +2,16 @@ import copy
 import uuid
 from unittest.mock import patch
 
+from django.contrib import admin as django_admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.forms.widgets import MediaOrderConflictWarning
-from django.test import TestCase, override_settings, tag
+from django.test import RequestFactory, TestCase, override_settings, tag
 from django.urls import reverse
 
 from openwisp_notifications import settings as app_settings
+from openwisp_notifications.admin import OrganizationNotificationSettingsInline
 from openwisp_notifications.signals import notify
 from openwisp_notifications.swapper import load_model, swapper_load_model
 from openwisp_notifications.templatetags.notification_tags import (
@@ -17,7 +19,7 @@ from openwisp_notifications.templatetags.notification_tags import (
 )
 from openwisp_notifications.types import NOTIFICATION_TYPES
 from openwisp_notifications.widgets import _add_object_notification_widget
-from openwisp_users.admin import UserAdmin
+from openwisp_users.admin import OrganizationAdmin, UserAdmin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 
 from .test_helpers import MessagingRequest, get_notification_setting_permission
@@ -27,6 +29,7 @@ NotificationSetting = load_model("NotificationSetting")
 notification_queryset = Notification.objects.order_by("-timestamp")
 Group = swapper_load_model("openwisp_users", "Group")
 OrganizationUser = swapper_load_model("openwisp_users", "OrganizationUser")
+Organization = swapper_load_model("openwisp_users", "Organization")
 
 
 class MockUser:
@@ -387,6 +390,20 @@ class TestOrganizationNotificationsSettingsAdmin(BaseTestAdmin):
                 response,
                 '<select name="notification_settings-0-email"',
             )
+
+    def test_disabled_organization_inline_readonly(self):
+        org_admin = OrganizationAdmin(Organization, django_admin.site)
+        active_org = self._get_org()
+        disabled_org = self._create_org(name="disabled-org", is_active=False)
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        self._test_disabled_org_admin_inline_readonly(
+            org_admin,
+            disabled_org,
+            active_obj=active_org,
+            inline_models=(OrganizationNotificationSettingsInline,),
+            user=request.user,
+        )
 
 
 @tag("skip_prod")

--- a/openwisp_notifications/tests/test_api.py
+++ b/openwisp_notifications/tests/test_api.py
@@ -249,6 +249,59 @@ class TestNotificationApi(
             self.assertIsNone(response.data)
             self.assertFalse(Notification.objects.all())
 
+    def test_notification_of_disabled_organization_remains_usable(self):
+        org_user = self._get_org_user()
+        org = org_user.organization
+        notify.send(sender=self.admin, type="default", target=org_user)
+        n = Notification.objects.first()
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        with self.subTest("Retrieving a disabled-org notification still works"):
+            url = self._get_path("notification_detail", n.pk)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Listing still includes disabled-org notifications"):
+            url = self._get_path("notifications_list")
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data["count"], 1)
+
+        with self.subTest("Marking a disabled-org notification as read still works"):
+            url = self._get_path("notification_detail", n.pk)
+            response = self.client.patch(url)
+            self.assertEqual(response.status_code, 200)
+            n.refresh_from_db()
+            self.assertEqual(n.unread, False)
+
+        with self.subTest("Redirecting from a disabled-org notification still works"):
+            n.unread = True
+            n.save(update_fields=["unread"])
+            url = self._get_path("notification_read_redirect", n.pk)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.url, n.target_url)
+            n.refresh_from_db()
+            self.assertEqual(n.unread, False)
+
+        with self.subTest(
+            "Marking all as read still covers disabled-org notifications"
+        ):
+            n.unread = True
+            n.save(update_fields=["unread"])
+            url = self._get_path("notifications_read_all")
+            response = self.client.post(url)
+            self.assertEqual(response.status_code, 200)
+            n.refresh_from_db()
+            self.assertEqual(n.unread, False)
+
+        with self.subTest("Deleting a disabled-org notification still works"):
+            url = self._get_path("notification_detail", n.pk)
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204)
+            self.assertEqual(Notification.objects.filter(pk=n.pk).exists(), False)
+
     def test_anonymous_user(self):
         response_data = {
             "detail": ErrorDetail(
@@ -1172,6 +1225,19 @@ class TestNotificationApi(
                 NotificationSetting.objects.filter(
                     user=self.admin, organization_id=org.pk, email=True
                 ).exists()
+            )
+
+        with self.subTest("Test disabled organization"):
+            org.is_active = False
+            org.save(update_fields=["is_active"])
+            url = self._get_path("user_org_notification_setting", self.admin.pk, org.pk)
+            response = self.client.post(url, data={"web": True, "email": True})
+            self.assertEqual(response.status_code, 404)
+            self.assertEqual(
+                NotificationSetting.objects.filter(
+                    user=self.admin, organization_id=org.pk, email=True
+                ).exists(),
+                False,
             )
 
     @patch("openwisp_notifications.tasks.delete_ignore_object_notification.apply_async")

--- a/openwisp_notifications/tests/test_helpers.py
+++ b/openwisp_notifications/tests/test_helpers.py
@@ -1,6 +1,7 @@
 import functools
 from copy import deepcopy
 from datetime import datetime
+from functools import wraps
 from unittest.mock import patch
 
 from django.contrib.auth.models import Permission
@@ -98,7 +99,7 @@ def mock_notification_types(func):
         ):
             return func(*args, **kwargs)
 
-    return wrapper
+    return wraps(func)(wrapper)
 
 
 class GetEditFormInlineMixin(object):

--- a/openwisp_notifications/tests/test_notifications.py
+++ b/openwisp_notifications/tests/test_notifications.py
@@ -1476,11 +1476,14 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             is_valid = email_token_generator.check_token(self.admin, token)
             self.assertFalse(is_valid)
 
+    def _get_unsubscribe_url(self, user):
+        full_url = get_unsubscribe_url_for_user(user, False)
+        token = full_url.split("?token=")[1]
+        return f'{reverse("notifications:unsubscribe")}?token={token}'
+
     def test_email_unsubscribe_view(self):
-        unsubscribe_link_generated = get_unsubscribe_url_for_user(self.admin, False)
-        token = unsubscribe_link_generated.split("?token=")[1]
         local_unsubscribe_url = reverse("notifications:unsubscribe")
-        unsubscribe_url = f"{local_unsubscribe_url}?token={token}"
+        unsubscribe_url = self._get_unsubscribe_url(self.admin)
 
         with self.subTest("Test GET request with valid token"):
             response = self.client.get(unsubscribe_url)
@@ -1564,6 +1567,34 @@ class TestNotifications(TestOrganizationMixin, TransactionTestCase):
             )
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.json()["message"], "Invalid JSON data")
+
+    def test_unsubscribe_and_resubscribe_apply_to_disabled_organizations(self):
+        org = self._create_org(name="unsub-org")
+        org_settings_queryset = NotificationSetting.objects.filter(
+            user=self.admin, organization=org
+        )
+        org_settings_queryset.update(email=True)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        unsubscribe_url = self._get_unsubscribe_url(self.admin)
+
+        with self.subTest("Unsubscribing also disables disabled-org settings"):
+            response = self.client.post(unsubscribe_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                set(org_settings_queryset.values_list("email", flat=True)), {False}
+            )
+
+        with self.subTest("Re-subscribing also re-enables disabled-org settings"):
+            response = self.client.post(
+                unsubscribe_url,
+                data=json.dumps({"subscribe": True}),
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                set(org_settings_queryset.values_list("email", flat=True)), {True}
+            )
 
     def test_notification_preference_page(self):
         preference_page = "notifications:user_notification_preference"
@@ -2074,6 +2105,34 @@ class TestNotificationSending(TestOrganizationMixin, TransactionTestCase):
             self._send_notification("default")
             self._assert_notification_created(False)
             self._assert_email_sent(False)
+
+    def test_notification_not_created_for_disabled_organization(self):
+        with self.subTest("Target organization disabled"):
+            self.org.is_active = False
+            self.org.save(update_fields=["is_active"])
+            with patch(
+                "openwisp_notifications.handlers.ws_handlers"
+                ".notification_update_handler"
+            ) as mocked_handler:
+                self._send_notification("default")
+            self._assert_notification_created(False)
+            self._assert_email_sent(False)
+            mocked_handler.assert_not_called()
+
+        with self.subTest("No target, organization disabled"):
+            self._send_notification("default", target=None)
+            count = Notification.objects.filter(recipient=self.admin).count()
+            self.assertEqual(count, 1)
+
+        Notification.objects.all().delete()
+        mail.outbox.clear()
+
+        with self.subTest("Target organization re-enabled"):
+            self.org.is_active = True
+            self.org.save(update_fields=["is_active"])
+            self._send_notification("default")
+            self._assert_notification_created(True)
+            self._assert_email_sent(True)
 
 
 class TestTransactionNotifications(TestOrganizationMixin, TransactionTestCase):

--- a/openwisp_notifications/views.py
+++ b/openwisp_notifications/views.py
@@ -237,6 +237,11 @@ class UnsubscribeView(TemplateView):
         """
         Update all of the user's notification settings to set email preference.
         """
+        # This user-wide switch deliberately allows disabled organizations too:
+        # skipping them would leave their preferences out of sync with the
+        # user's choice and silently resume emails once the organization is
+        # re-enabled. Per-organization toggles are blocked instead, see
+        # UserOrgNotificationSettingView.
         NotificationSetting.objects.filter(user=user).update(email=subscribe)
 
 


### PR DESCRIPTION



## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-notifications/issues/new/choose) if there isn't an existing issue yet. -->

Closes #472

## Description of Changes

Stopped generating notifications for objects belonging to disabled organizations while keeping existing notifications usable. Blocked per-organization preference updates for disabled organizations, while preserving user-wide unsubscribe behavior.

Added regression tests and updated the related documentation.

## Blockers 

- [ ] https://github.com/openwisp/openwisp-users/pull/542

## Screenshot

**Notification Settings in OrganizationAdmin is rendered as readonly**

<img width="1359" height="652" alt="image" src="https://github.com/user-attachments/assets/13dc6ed8-5486-42a4-8f23-fa66cb9d33b4" />
